### PR TITLE
Adjust listwork layout for responsiveness

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -59,12 +59,9 @@ export default function IndexPage() {
         <AppLink href="/work" className="btn btn-primary mb-8">
           View Process
         </AppLink>
-
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-          {works.map((post) => (
-            <AppListPortfolio key={post.slug} data={post} />
-          ))}
-        </div>
+        {works.map((post) => (
+          <AppListPortfolio key={post.slug} data={post} />
+        ))}
       </div>
 
       {/* Blog Section */}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -59,9 +59,12 @@ export default function IndexPage() {
         <AppLink href="/work" className="btn btn-primary mb-8">
           View Process
         </AppLink>
-        {works.map((post) => (
-          <AppListPortfolio key={post.slug} data={post} />
-        ))}
+
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          {works.map((post) => (
+            <AppListPortfolio key={post.slug} data={post} />
+          ))}
+        </div>
       </div>
 
       {/* Blog Section */}

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -17,14 +17,12 @@ export default function WorkListPage() {
         </p>
       </div>
 
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-          {works
-            .filter((post) => post.feature === true && post.draft !== true)
-            .sort(sortByDate)
-            .map((post) => (
-              <AppListPortfolio key={post.slug} data={post} />
-            ))}
-        </div>
+        {works
+          .filter((post) => post.feature === true && post.draft !== true)
+          .sort(sortByDate)
+          .map((post) => (
+            <AppListPortfolio key={post.slug} data={post} />
+          ))}
       <h2 className="text-sm uppercase tracking-wide font-heading font-semibold text-secondarytext mb-4">
         Side Projects
       </h2>

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -17,12 +17,14 @@ export default function WorkListPage() {
         </p>
       </div>
 
-      {works
-        .filter((post) => post.feature === true && post.draft !== true)
-        .sort(sortByDate)
-        .map((post) => (
-          <AppListPortfolio key={post.slug} data={post} />
-        ))}
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          {works
+            .filter((post) => post.feature === true && post.draft !== true)
+            .sort(sortByDate)
+            .map((post) => (
+              <AppListPortfolio key={post.slug} data={post} />
+            ))}
+        </div>
       <h2 className="text-sm uppercase tracking-wide font-heading font-semibold text-secondarytext mb-4">
         Side Projects
       </h2>

--- a/components/AppListPortfolio.tsx
+++ b/components/AppListPortfolio.tsx
@@ -8,7 +8,7 @@ export default function AppListPortfolio({ data }: any) {
   return (
     <div
       role="group"
-      className="grid grid-cols-1 gap-8 my-10 border border-border p-6 rounded-2xl lg:grid-cols-[1fr_auto] lg:gap-16 lg:p-8"
+      className="grid h-full w-full grid-cols-1 gap-8 border border-border p-6 rounded-2xl lg:grid-cols-[1fr_auto] lg:gap-16 lg:p-8"
     >
       <div className="order-2 flex flex-col items-start gap-4 lg:order-1 lg:gap-2">
         <p className="text-sm text-secondarytext font-heading mb-0">{post.subtitle}</p>

--- a/components/AppListPortfolio.tsx
+++ b/components/AppListPortfolio.tsx
@@ -8,7 +8,7 @@ export default function AppListPortfolio({ data }: any) {
   return (
     <div
       role="group"
-      className="grid h-full w-full grid-cols-1 gap-8 border border-border p-6 rounded-2xl lg:grid-cols-2 lg:gap-12 lg:p-8"
+      className="grid grid-cols-1 gap-8 my-10 border border-border p-6 rounded-2xl lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] lg:gap-16 lg:p-8"
     >
       <div className="order-2 flex flex-col items-start gap-4 lg:order-1 lg:gap-2">
         <p className="text-sm text-secondarytext font-heading mb-0">{post.subtitle}</p>
@@ -18,7 +18,7 @@ export default function AppListPortfolio({ data }: any) {
           <Link href={`/work/${post.slug}/`}>View Process</Link>
         </Button>
       </div>
-      <div className="order-1 w-full overflow-hidden rounded-xl lg:order-2">
+      <div className="order-1 w-full overflow-hidden rounded-xl lg:order-2 lg:h-full">
         <Image
           src={post.cover}
           alt={post.title}

--- a/components/AppListPortfolio.tsx
+++ b/components/AppListPortfolio.tsx
@@ -8,7 +8,7 @@ export default function AppListPortfolio({ data }: any) {
   return (
     <div
       role="group"
-      className="grid h-full w-full grid-cols-1 gap-8 border border-border p-6 rounded-2xl lg:grid-cols-[1fr_auto] lg:gap-16 lg:p-8"
+      className="grid h-full w-full grid-cols-1 gap-8 border border-border p-6 rounded-2xl lg:grid-cols-2 lg:gap-12 lg:p-8"
     >
       <div className="order-2 flex flex-col items-start gap-4 lg:order-1 lg:gap-2">
         <p className="text-sm text-secondarytext font-heading mb-0">{post.subtitle}</p>


### PR DESCRIPTION
Implement responsive grid layout for `AppListPortfolio` on Home and Work pages to display as 50% width on desktop and single column on mobile.

---
<a href="https://cursor.com/background-agent?bcId=bc-57001f77-b089-4ef1-8452-349d989c7bf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-57001f77-b089-4ef1-8452-349d989c7bf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use equal-width two-column grid on desktop and make the image container fill available height for better responsiveness.
> 
> - **Frontend**:
>   - **`components/AppListPortfolio.tsx`**:
>     - Change desktop grid from `lg:grid-cols-[1fr_auto]` to `lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]` for equal-width columns.
>     - Add `lg:h-full` to the image wrapper to ensure full-height image area.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7db66e66d4bd27fc39b994a700a4d447ca268a07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->