### PR TITLE
refactor RSS feed generation to use the latest post date for pubDate …

### DIFF
--- a/app/rss.xml/route.tsx
+++ b/app/rss.xml/route.tsx
@@ -5,6 +5,8 @@ import { sortByDate } from "../../utils";
 import CONFIG from "../../config.js";
 
 export async function GET() {
+  const sorted = [...filteredPosts].sort(sortByDate);
+  const latestPostDate = sorted[0]?.date ? new Date(sorted[0].date) : new Date(0);
   const feed = new RSS({
     title: CONFIG.TITLE,
     description: CONFIG.DESCRIPTION,
@@ -14,13 +16,11 @@ export async function GET() {
     webMaster: CONFIG.AUTHOR_NAME,
     copyright: CONFIG.COPYRIGHT,
     language: CONFIG.LOCALE,
-    pubDate: new Date().toLocaleString(),
+    pubDate: latestPostDate,
     ttl: 60,
   });
 
-  filteredPosts
-    .sort(sortByDate)
-    .forEach((post) => {
+  sorted.forEach((post) => {
       feed.item({
         title: post.title,
         description: post.body.raw,


### PR DESCRIPTION
…and improve sorting logic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor limited to RSS metadata and post ordering; main risk is subtle date formatting/empty-feed behavior affecting RSS consumers.
> 
> **Overview**
> RSS generation in `app/rss.xml/route.tsx` now sorts `filteredPosts` once into `sorted` and uses the newest post’s date (fallback `new Date(0)`) as the feed-level `pubDate` instead of the current time string.
> 
> The same `sorted` list is then reused to add feed items, avoiding re-sorting/mutating `filteredPosts` during iteration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e169ff41c2f8396ea98cec04d34029fec2b19c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->