### PR TITLE
feat(blog): redesign blog post layout with narrow column and prose ty…

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,7 +2,7 @@ name: E2E Tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
 
 jobs:
@@ -14,8 +14,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,32 @@
+name: E2E Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  scrollspy-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install chromium --with-deps
+
+      - name: Run scrollspy smoke tests
+        run: pnpm test:e2e:smoke

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,5 +26,5 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm exec playwright install chromium --with-deps
 
-      - name: Run scrollspy smoke tests
-        run: pnpm test:e2e:smoke
+      - name: Run scrollspy CI smoke tests
+        run: pnpm test:e2e:ci

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
 
 # next.js
 /.next/

--- a/app/[slug]/ScrollspyNav.tsx
+++ b/app/[slug]/ScrollspyNav.tsx
@@ -2,6 +2,10 @@
 
 import React from "react";
 import Link from "next/link";
+import { prepare, layout } from "@chenglou/pretext";
+
+const HEADER_HEIGHT = 68;
+const READING_POSITION = () => window.innerHeight * 0.4;
 
 type Heading = {
   id: string;
@@ -9,45 +13,151 @@ type Heading = {
   level: number;
 };
 
+type Section = {
+  id: string;
+  top: number;   // px from document top
+  bottom: number;
+};
+
+function getSectionText(fromEl: Element, toEl: Element | null): string {
+  let text = "";
+  let node: Node | null = fromEl.nextSibling;
+  while (node && node !== toEl) {
+    if (node.textContent) text += node.textContent + " ";
+    node = node.nextSibling;
+  }
+  return text.trim();
+}
+
+function buildSections(headings: Heading[]): Section[] {
+  const sections: Section[] = [];
+
+  // Find the article element that wraps all headings
+  const firstEl = document.getElementById(headings[0]?.id);
+  const article = firstEl?.closest("article") ?? firstEl?.parentElement ?? null;
+
+  // Gather computed font info from the article for pretext
+  let font = "16px sans-serif";
+  let lineHeightPx = 32; // 16px * 2 (our leading-[2])
+  let containerWidth = 672; // max-w-2xl fallback
+
+  if (article) {
+    const style = getComputedStyle(article);
+    const fontSize = parseFloat(style.fontSize) || 16;
+    const fontFamily = style.fontFamily || "sans-serif";
+    const lh = parseFloat(style.lineHeight);
+    font = `${fontSize}px ${fontFamily}`;
+    lineHeightPx = isNaN(lh) ? fontSize * 2 : lh;
+    containerWidth = article.clientWidth || containerWidth;
+  }
+
+  for (let i = 0; i < headings.length; i++) {
+    const el = document.getElementById(headings[i].id);
+    if (!el) continue;
+
+    const top = el.getBoundingClientRect().top + window.scrollY;
+    const nextEl = headings[i + 1] ? document.getElementById(headings[i + 1].id) : null;
+
+    // Estimate section height via pretext
+    let bottom: number;
+    if (nextEl) {
+      const nextTop = nextEl.getBoundingClientRect().top + window.scrollY;
+      // Use pretext to estimate content height, take the larger of DOM measurement vs estimate
+      const sectionText = getSectionText(el, nextEl);
+      let pretextBottom = top;
+      if (sectionText.length > 0) {
+        try {
+          const prepared = prepare(sectionText, font);
+          const measured = layout(prepared, containerWidth, lineHeightPx);
+          pretextBottom = top + measured.height;
+        } catch {
+          pretextBottom = nextTop;
+        }
+      }
+      bottom = Math.max(nextTop, pretextBottom);
+    } else {
+      // Last section: use pretext estimate, fall back to page bottom
+      const sectionText = getSectionText(el, null);
+      let pretextBottom = document.documentElement.scrollHeight;
+      if (sectionText.length > 0) {
+        try {
+          const prepared = prepare(sectionText, font);
+          const measured = layout(prepared, containerWidth, lineHeightPx);
+          pretextBottom = top + measured.height;
+        } catch {
+          // keep document bottom
+        }
+      }
+      bottom = pretextBottom;
+    }
+
+    sections.push({ id: headings[i].id, top, bottom });
+  }
+
+  return sections;
+}
+
 type ScrollspyNavProps = {
   headings: Heading[];
 };
 
 export default function ScrollspyNav({ headings }: ScrollspyNavProps) {
   const [activeId, setActiveId] = React.useState<string>("");
+  const sectionsRef = React.useRef<Section[]>([]);
+  const rafRef = React.useRef<number | null>(null);
+  const resizeTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  React.useEffect(() => {
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            setActiveId(entry.target.id);
-          }
-        });
-      },
-      {
-        // To account for a 68px header and trigger when the heading is near the center of the viewport,
-        // set rootMargin so the observed point is the center minus header height.
-        rootMargin: `-${(window.innerHeight / 2) - 68}px 0px -${(window.innerHeight / 2) - 68}px 0px`,
-      }
-    );
-
-    // Observe all headings
-    headings.forEach((heading) => {
-      const element = document.getElementById(heading.id);
-      if (element) {
-        observer.observe(element);
-      }
-    });
-
-    return () => {
-      observer.disconnect();
-    };
+  const recalculate = React.useCallback(() => {
+    if (headings.length === 0) return;
+    sectionsRef.current = buildSections(headings);
   }, [headings]);
 
-  if (headings.length === 0) {
-    return null;
-  }
+  const onScroll = React.useCallback(() => {
+    if (rafRef.current !== null) return;
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      const sections = sectionsRef.current;
+      if (sections.length === 0) return;
+
+      const readingY = window.scrollY + READING_POSITION();
+
+      // Last section whose top is at or above the reading position
+      let active = sections[0].id;
+      for (const section of sections) {
+        if (readingY >= section.top) {
+          active = section.id;
+        }
+      }
+      setActiveId(active);
+    });
+  }, []);
+
+  React.useEffect(() => {
+    if (headings.length === 0) return;
+
+    recalculate();
+    onScroll(); // set initial active without waiting for a scroll event
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+
+    const onResize = () => {
+      if (resizeTimerRef.current) clearTimeout(resizeTimerRef.current);
+      resizeTimerRef.current = setTimeout(() => {
+        recalculate();
+        onScroll();
+      }, 200);
+    };
+    window.addEventListener("resize", onResize);
+
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onResize);
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+      if (resizeTimerRef.current) clearTimeout(resizeTimerRef.current);
+    };
+  }, [headings, recalculate, onScroll]);
+
+  if (headings.length === 0) return null;
 
   return (
     <aside className="fixed top-1/2 right-4 transform -translate-y-1/2 hidden xl:block max-w-48 z-50">
@@ -70,10 +180,8 @@ export default function ScrollspyNav({ headings }: ScrollspyNavProps) {
                   e.preventDefault();
                   const element = document.getElementById(heading.id);
                   if (element) {
-                    element.scrollIntoView({
-                      behavior: "smooth",
-                      block: "start",
-                    });
+                    const top = element.getBoundingClientRect().top + window.scrollY - READING_POSITION();
+                    window.scrollTo({ top, behavior: "smooth" });
                   }
                 }}
               >
@@ -85,4 +193,4 @@ export default function ScrollspyNav({ headings }: ScrollspyNavProps) {
       </nav>
     </aside>
   );
-} 
+}

--- a/app/[slug]/ScrollspyNav.tsx
+++ b/app/[slug]/ScrollspyNav.tsx
@@ -1,189 +1,134 @@
 "use client";
 
 import React from "react";
-import Link from "next/link";
-import { prepare, layout } from "@chenglou/pretext";
+import ScrollSpy from "@fsegurai/scrollspy";
+import { Link } from "@/components/AppLink";
+import {
+  collectHeadingsFromDom,
+  getScrollContentRoot,
+  type DomHeading,
+} from "../../utils/collectHeadingsFromDom";
+import {
+  readingLineOffset,
+  scrollToHeadingAtReadingLine,
+} from "../../utils/scrollToHeading";
+import { waitForScrollEnd } from "../../utils/waitForScrollEnd";
 
-const HEADER_HEIGHT = 68;
-const READING_POSITION = () => window.innerHeight * 0.4;
+const ITEM_CLASS =
+  "border-l border-gray-200 dark:border-gray-600 pl-2 py-1 transition-colors text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 [&.active]:border-primary-500 [&.active]:dark:border-primary-500 [&.active]:text-primary-500 [&.active]:font-bold";
 
-type Heading = {
-  id: string;
-  text: string;
-  level: number;
-};
-
-type Section = {
-  id: string;
-  top: number;   // px from document top
-  bottom: number;
-};
-
-function getSectionText(fromEl: Element, toEl: Element | null): string {
-  let text = "";
-  let node: Node | null = fromEl.nextSibling;
-  while (node && node !== toEl) {
-    if (node.textContent) text += node.textContent + " ";
-    node = node.nextSibling;
-  }
-  return text.trim();
+function activateNavItem(headingId: string) {
+  document
+    .querySelectorAll("#scrollspy-nav li.active")
+    .forEach((li) => li.classList.remove("active"));
+  document
+    .querySelector(`#scrollspy-nav a[href="#${headingId}"]`)
+    ?.closest("li")
+    ?.classList.add("active");
 }
 
-function buildSections(headings: Heading[]): Section[] {
-  const sections: Section[] = [];
-
-  // Find the article element that wraps all headings
-  const firstEl = document.getElementById(headings[0]?.id);
-  const article = firstEl?.closest("article") ?? firstEl?.parentElement ?? null;
-
-  // Gather computed font info from the article for pretext
-  let font = "16px sans-serif";
-  let lineHeightPx = 32; // 16px * 2 (our leading-[2])
-  let containerWidth = 672; // max-w-2xl fallback
-
-  if (article) {
-    const style = getComputedStyle(article);
-    const fontSize = parseFloat(style.fontSize) || 16;
-    const fontFamily = style.fontFamily || "sans-serif";
-    const lh = parseFloat(style.lineHeight);
-    font = `${fontSize}px ${fontFamily}`;
-    lineHeightPx = isNaN(lh) ? fontSize * 2 : lh;
-    containerWidth = article.clientWidth || containerWidth;
-  }
-
-  for (let i = 0; i < headings.length; i++) {
-    const el = document.getElementById(headings[i].id);
-    if (!el) continue;
-
-    const top = el.getBoundingClientRect().top + window.scrollY;
-    const nextEl = headings[i + 1] ? document.getElementById(headings[i + 1].id) : null;
-
-    // Estimate section height via pretext
-    let bottom: number;
-    if (nextEl) {
-      const nextTop = nextEl.getBoundingClientRect().top + window.scrollY;
-      // Use pretext to estimate content height, take the larger of DOM measurement vs estimate
-      const sectionText = getSectionText(el, nextEl);
-      let pretextBottom = top;
-      if (sectionText.length > 0) {
-        try {
-          const prepared = prepare(sectionText, font);
-          const measured = layout(prepared, containerWidth, lineHeightPx);
-          pretextBottom = top + measured.height;
-        } catch {
-          pretextBottom = nextTop;
-        }
-      }
-      bottom = Math.max(nextTop, pretextBottom);
-    } else {
-      // Last section: use pretext estimate, fall back to page bottom
-      const sectionText = getSectionText(el, null);
-      let pretextBottom = document.documentElement.scrollHeight;
-      if (sectionText.length > 0) {
-        try {
-          const prepared = prepare(sectionText, font);
-          const measured = layout(prepared, containerWidth, lineHeightPx);
-          pretextBottom = top + measured.height;
-        } catch {
-          // keep document bottom
-        }
-      }
-      bottom = pretextBottom;
-    }
-
-    sections.push({ id: headings[i].id, top, bottom });
-  }
-
-  return sections;
+function sameHeadingIds(a: DomHeading[], b: DomHeading[]): boolean {
+  return (
+    a.length === b.length &&
+    a.every((heading, index) => heading.id === b[index]?.id)
+  );
 }
 
-type ScrollspyNavProps = {
-  headings: Heading[];
-};
+export default function ScrollspyNav() {
+  const [headings, setHeadings] = React.useState<DomHeading[]>([]);
+  const spyRef = React.useRef<ScrollSpy | null>(null);
 
-export default function ScrollspyNav({ headings }: ScrollspyNavProps) {
-  const [activeId, setActiveId] = React.useState<string>("");
-  const sectionsRef = React.useRef<Section[]>([]);
-  const rafRef = React.useRef<number | null>(null);
-  const resizeTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  React.useEffect(() => {
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+    const root = getScrollContentRoot();
+    if (!root) return;
 
-  const recalculate = React.useCallback(() => {
-    if (headings.length === 0) return;
-    sectionsRef.current = buildSections(headings);
-  }, [headings]);
+    const refreshHeadings = () => {
+      const next = collectHeadingsFromDom(root);
+      setHeadings((prev) => (sameHeadingIds(next, prev) ? prev : next));
+    };
 
-  const onScroll = React.useCallback(() => {
-    if (rafRef.current !== null) return;
-    rafRef.current = requestAnimationFrame(() => {
-      rafRef.current = null;
-      const sections = sectionsRef.current;
-      if (sections.length === 0) return;
+    refreshHeadings();
 
-      const readingY = window.scrollY + READING_POSITION();
-
-      // Last section whose top is at or above the reading position
-      let active = sections[0].id;
-      for (const section of sections) {
-        if (readingY >= section.top) {
-          active = section.id;
-        }
-      }
-      setActiveId(active);
+    const observer = new MutationObserver(() => {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(refreshHeadings, 300);
     });
+
+    observer.observe(root, { childList: true, subtree: true });
+    window.addEventListener("load", refreshHeadings);
+
+    return () => {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      observer.disconnect();
+      window.removeEventListener("load", refreshHeadings);
+    };
   }, []);
 
   React.useEffect(() => {
-    if (headings.length === 0) return;
+    if (headings.length === 0) {
+      spyRef.current?.destroy();
+      spyRef.current = null;
+      return;
+    }
 
-    recalculate();
-    onScroll(); // set initial active without waiting for a scroll event
+    spyRef.current?.destroy();
+    spyRef.current = new ScrollSpy("#scrollspy-nav", {
+      offset: readingLineOffset,
+      bottomThreshold: 100,
+      reflow: true,
+      events: true,
+    });
 
-    window.addEventListener("scroll", onScroll, { passive: true });
-
-    const onResize = () => {
-      if (resizeTimerRef.current) clearTimeout(resizeTimerRef.current);
-      resizeTimerRef.current = setTimeout(() => {
-        recalculate();
-        onScroll();
-      }, 200);
-    };
-    window.addEventListener("resize", onResize);
+    requestAnimationFrame(() => {
+      spyRef.current?.detect();
+      if (
+        window.scrollY < 50 &&
+        !document.querySelector("#scrollspy-nav li.active") &&
+        headings[0]
+      ) {
+        activateNavItem(headings[0].id);
+      }
+    });
 
     return () => {
-      window.removeEventListener("scroll", onScroll);
-      window.removeEventListener("resize", onResize);
-      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
-      if (resizeTimerRef.current) clearTimeout(resizeTimerRef.current);
+      spyRef.current?.destroy();
+      spyRef.current = null;
     };
-  }, [headings, recalculate, onScroll]);
+  }, [headings]);
+
+  const handleHeadingClick = React.useCallback(
+    (event: React.MouseEvent<HTMLAnchorElement>, headingId: string) => {
+      event.preventDefault();
+      const element = document.getElementById(headingId);
+      if (!element) return;
+
+      const startY = window.scrollY;
+      const targetTop = scrollToHeadingAtReadingLine(element, "smooth");
+      waitForScrollEnd(() => activateNavItem(headingId), {
+        expectMovement: Math.abs(targetTop - startY) > 1,
+        startY,
+      });
+    },
+    []
+  );
 
   if (headings.length === 0) return null;
 
   return (
     <aside className="fixed top-1/2 right-4 transform -translate-y-1/2 hidden xl:block max-w-48 z-50">
-      <nav className="text-sm">
+      <nav id="scrollspy-nav" className="text-sm">
         <ul className="list-none">
-          {headings.map((heading, index) => (
+          {headings.map((heading) => (
             <li
-              key={index}
-              className={`border-l border-gray-200 dark:border-gray-600 pl-2 py-1 transition-colors ${
-                activeId === heading.id
-                  ? "border-primary-500 dark:border-primary-500 text-primary-500 font-bold"
-                  : "text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100"
-              }`}
+              key={heading.id}
+              className={ITEM_CLASS}
               style={{ paddingLeft: `${8 + (heading.level - 1) * 8}px` }}
             >
               <Link
                 href={`#${heading.id}`}
                 className="block hover:text-primary-500 transition-colors"
-                onClick={(e) => {
-                  e.preventDefault();
-                  const element = document.getElementById(heading.id);
-                  if (element) {
-                    const top = element.getBoundingClientRect().top + window.scrollY - READING_POSITION();
-                    window.scrollTo({ top, behavior: "smooth" });
-                  }
-                }}
+                onClick={(event) => handleHeadingClick(event, heading.id)}
               >
                 {heading.text}
               </Link>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,13 +1,20 @@
 import type { Metadata } from 'next'
-import { Space_Grotesk, Manrope } from 'next/font/google'
+import { Space_Grotesk, Manrope, Space_Mono } from 'next/font/google'
 import localFont from 'next/font/local'
 import '../styles/globals.css'
 import AnalyticsProvider from '@/components/AnalyticsProvider'
 
-const spaceGrotesk = Space_Grotesk({ 
+const spaceGrotesk = Space_Grotesk({
   subsets: ['latin'],
   display: 'swap',
   variable: '--font-space-grotesk',
+})
+
+const spaceMono = Space_Mono({
+  subsets: ['latin'],
+  display: 'swap',
+  weight: ['400', '700'],
+  variable: '--font-space-mono',
 })
 
 // const publicSans = Manrope({ 
@@ -97,7 +104,7 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en" className={`${spaceGrotesk.variable} ${publicSans.variable}`}>
+    <html lang="en" className={`${spaceGrotesk.variable} ${publicSans.variable} ${spaceMono.variable}`}>
       <body className={`${spaceGrotesk.className} ${publicSans.className}`}>
         {children}
         <AnalyticsProvider gaId={process.env.NEXT_PUBLIC_MEASUREMENT_ID ?? ''} />

--- a/components/AppLink.tsx
+++ b/components/AppLink.tsx
@@ -7,7 +7,7 @@ type AppLinkProps = {
   style?: React.CSSProperties;
   target?: "_blank" | "_self";
   title?: string;
-  onClick?: () => void;
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
 };
 
 function AppLink({

--- a/components/BlogLayout.tsx
+++ b/components/BlogLayout.tsx
@@ -5,7 +5,6 @@ import Link from "next/link";
 import AppListBlog from "@/components/AppListBlog";
 import AppNavBar from "@/components/AppNavBar";
 import AppFooter from "@/components/AppFooter";
-import { getHeadings } from "../utils/getHeadings";
 import ScrollspyNav from "../app/[slug]/ScrollspyNav";
 import ScrollToTop from "../app/[slug]/ScrollToTop";
 import kebabCase from "lodash.kebabcase";
@@ -17,8 +16,6 @@ interface BlogLayoutProps {
 }
 
 export default function BlogLayout({ post, relatedPosts }: BlogLayoutProps) {
-  const headings = getHeadings(post.body.raw);
-
   return (
     <div className="min-h-screen flex flex-col bg-background">
       <AppNavBar />
@@ -64,8 +61,6 @@ export default function BlogLayout({ post, relatedPosts }: BlogLayoutProps) {
 
           {/* MDX body */}
           <BlogMDXContent code={post.body.code} />
-
-          {/* Tags */}
           {post.tags.length > 0 && (
             <div className="flex flex-wrap gap-2 mt-10 pt-8 border-t border-border">
               {post.tags.map((tag) => (
@@ -106,7 +101,7 @@ export default function BlogLayout({ post, relatedPosts }: BlogLayoutProps) {
 
       <AppFooter />
 
-      {headings.length > 0 && <ScrollspyNav headings={headings} />}
+      <ScrollspyNav />
       <ScrollToTop />
     </div>
   );

--- a/components/BlogLayout.tsx
+++ b/components/BlogLayout.tsx
@@ -3,12 +3,13 @@ import dayjs from "dayjs";
 import Image from "next/image";
 import Link from "next/link";
 import AppListBlog from "@/components/AppListBlog";
-import AppLayout from "@/components/AppLayout";
+import AppNavBar from "@/components/AppNavBar";
+import AppFooter from "@/components/AppFooter";
 import { getHeadings } from "../utils/getHeadings";
 import ScrollspyNav from "../app/[slug]/ScrollspyNav";
 import ScrollToTop from "../app/[slug]/ScrollToTop";
 import kebabCase from "lodash.kebabcase";
-import MDXContent from "@/components/mdx-components";
+import BlogMDXContent from "@/components/BlogMDXContent";
 
 interface BlogLayoutProps {
   post: Post;
@@ -19,69 +20,70 @@ export default function BlogLayout({ post, relatedPosts }: BlogLayoutProps) {
   const headings = getHeadings(post.body.raw);
 
   return (
-    <AppLayout>
-      <div className="min-h-screen">
-        {/* Main Content */}
-        <div className="max-w-3xl mx-auto px-4 py-8">
-          {/* Article Header */}
-          <article className="prose max-w-none">
-            <div className="mb-8">
-              <div className="inline-block">
-                <span className="text-sm font-heading font-medium text-slate-400">
-                  {post.category}
-                </span>
-              </div>
-              <h1 className="text-4xl md:text-5xl font-bold font-heading leading-tight text-foreground mt-2 mb-4">
-                {post.title}
-              </h1>
-              <p className="text-xl leading-relaxed text-secondarytext mb-6">
+    <div className="min-h-screen flex flex-col bg-background">
+      <AppNavBar />
+
+      <main className="flex-1">
+        {/* Narrow reading column */}
+        <div className="max-w-2xl mx-auto px-6 py-12">
+          {/* Cover image */}
+          {post.cover && (
+            <div className="not-prose block my-8 -mx-8 sm:-mx-16 md:-mx-24">
+              <Image
+                src={post.cover}
+                alt={post.title}
+                width={800}
+                height={400}
+                className="w-full h-auto rounded-md"
+                priority
+              />
+            </div>
+          )}
+
+          {/* Article header */}
+          <header className="mb-10">
+            {post.category && (
+              <span className="text-xs font-heading font-medium text-muted-foreground uppercase tracking-widest">
+                {post.category}
+              </span>
+            )}
+            <h1 className="text-2xl md:text-3xl font-bold font-heading leading-snug text-foreground mt-2 mb-3">
+              {post.title}
+            </h1>
+            {post.tldr && (
+              <p className="text-sm leading-relaxed text-secondarytext mb-4">
                 {post.tldr}
               </p>
-              <div className="flex items-center font-heading gap-2 text-sm text-gray-500">
-                <span>{dayjs(post.date).format("MMMM DD, YYYY")}</span>
-                <span>·</span>
-                <span>{post.timetoread} min read</span>
-              </div>
-            </div>
-
-            {/* Cover Image */}
-            {post.cover && (
-              <div className="mb-8">
-                <Image
-                  src={post.cover}
-                  alt={post.title}
-                  width={800}
-                  height={400}
-                  className="w-full h-auto rounded-lg"
-                  priority
-                />
-              </div>
             )}
+            <div className="flex items-center font-heading gap-2 text-xs text-muted-foreground">
+              <span>{dayjs(post.date).format("MMMM DD, YYYY")}</span>
+              <span>·</span>
+              <span>{post.timetoread} min read</span>
+            </div>
+          </header>
 
-            {/* Article Content */}
-            <MDXContent code={post.body.code} />
+          {/* MDX body */}
+          <BlogMDXContent code={post.body.code} />
 
-            {/* Tags */}
-            <div className="flex flex-wrap gap-2 mt-8">
+          {/* Tags */}
+          {post.tags.length > 0 && (
+            <div className="flex flex-wrap gap-2 mt-10 pt-8 border-t border-border">
               {post.tags.map((tag) => (
                 <Link
                   key={tag}
                   href={`/tags/${kebabCase(tag)}`}
-                  className="inline-block px-3 py-1 bg-gray-100 text-gray-700 rounded-full text-sm hover:bg-gray-200 transition-colors"
+                  className="inline-block px-3 py-1 bg-secondary text-secondary-foreground rounded-full text-xs font-mono hover:bg-accent transition-colors"
                 >
                   {tag}
                 </Link>
               ))}
             </div>
-          </article>
+          )}
 
-          {/* Table of Contents */}
-          {headings.length > 0 && <ScrollspyNav headings={headings} />}
-
-          {/* Related Posts */}
+          {/* Related posts */}
           {relatedPosts.length > 0 && (
-            <div className="mt-12 pt-8 border-t border-border ">
-              <h2 className="text-2xl font-bold text-foreground font-heading mb-6">Read more</h2>
+            <div className="mt-12 pt-8 border-t border-border">
+              <h2 className="text-base font-bold text-foreground font-heading mb-6">Read more</h2>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 {relatedPosts.map((relatedPost) => (
                   <AppListBlog key={relatedPost.slug} data={relatedPost} small />
@@ -90,20 +92,22 @@ export default function BlogLayout({ post, relatedPosts }: BlogLayoutProps) {
             </div>
           )}
 
-          {/* Back to Blog */}
-          <div className="mt-8 text-center">
+          {/* Back to blog */}
+          <div className="mt-10">
             <Link
               href="/blog"
-              className="inline-block text-foreground px-6 py-3 rounded-lg font-medium transition-colors"
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
             >
               ↖ More articles
             </Link>
           </div>
         </div>
-        
-        {/* Scroll to Top Button */}
-        <ScrollToTop />
-      </div>
-    </AppLayout>
+      </main>
+
+      <AppFooter />
+
+      {headings.length > 0 && <ScrollspyNav headings={headings} />}
+      <ScrollToTop />
+    </div>
   );
 }

--- a/components/BlogMDXContent.tsx
+++ b/components/BlogMDXContent.tsx
@@ -99,32 +99,35 @@ export default function BlogMDXContent({ code }: BlogMDXContentProps) {
   const MDXComponent = useMDXComponent(code);
 
   return (
-    <article className={cn(
-      "prose max-w-none",
-      // Headings
-      "prose-headings:font-heading prose-headings:text-foreground prose-headings:font-bold",
-      "prose-h1:text-2xl prose-h2:text-xl prose-h3:text-lg",
-      "prose-h2:mt-10 prose-h2:mb-4 prose-h3:mt-8 prose-h3:mb-3",
-      // Body text — [&_p]/[&_li] have explicit specificity, overriding prose's inherited 1.75
-      "prose-p:text-secondarytext [&_p]:leading-[2] prose-a:text-primary-500",
-      // Links
-      "prose-a:no-underline prose-a:border-b prose-a:border-primary-500 hover:prose-a:text-primary-600",
-      // Lists
-      "prose-li:text-secondarytext [&_li]:leading-[2]",
-      // Blockquote
-      "prose-blockquote:border-l-2 prose-blockquote:border-border prose-blockquote:text-secondarytext prose-blockquote:not-italic",
-      // Code
-      "prose-code:text-foreground prose-code:before:content-none prose-code:after:content-none",
-      "prose-pre:bg-card prose-pre:border prose-pre:border-border",
-      // Images — handled by custom component above (not-prose)
-      "prose-img:rounded-md",
-      // Strong/em
-      "prose-strong:text-foreground prose-strong:font-semibold",
-      // HR
-      "prose-hr:border-border",
-      // Dark mode
-      "dark:prose-invert",
-    )}>
+    <article
+      data-scroll-content
+      className={cn(
+        "prose max-w-none",
+        // Headings
+        "prose-headings:font-heading prose-headings:text-foreground prose-headings:font-bold",
+        "prose-h2:text-xl prose-h3:text-lg",
+        "prose-h2:mt-10 prose-h2:mb-4 prose-h3:mt-8 prose-h3:mb-3",
+        // Body text — [&_p]/[&_li] have explicit specificity, overriding prose's inherited 1.75
+        "prose-p:text-secondarytext [&_p]:leading-[2] prose-a:text-primary-500",
+        // Links
+        "prose-a:no-underline prose-a:border-b prose-a:border-primary-500 hover:prose-a:text-primary-600",
+        // Lists
+        "prose-li:text-secondarytext [&_li]:leading-[2]",
+        // Blockquote
+        "prose-blockquote:border-l-2 prose-blockquote:border-border prose-blockquote:text-secondarytext prose-blockquote:not-italic",
+        // Code
+        "prose-code:text-foreground prose-code:before:content-none prose-code:after:content-none",
+        "prose-pre:bg-card prose-pre:border prose-pre:border-border",
+        // Images — handled by custom component above (not-prose)
+        "prose-img:rounded-md",
+        // Strong/em
+        "prose-strong:text-foreground prose-strong:font-semibold",
+        // HR
+        "prose-hr:border-border",
+        // Dark mode
+        "dark:prose-invert",
+      )}
+    >
       <MDXComponent components={blogMdxComponents} />
     </article>
   );

--- a/components/BlogMDXContent.tsx
+++ b/components/BlogMDXContent.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useMDXComponent } from "next-contentlayer2/hooks";
+import Image from "next/image";
+import { cn } from "@/components/lib/utils";
+import SectionTitle from "@/components/mdx/SectionTitle";
+import TestimonialBox from "@/components/mdx/TestimonialBox";
+import LightboxImagePair from "@/components/mdx/LightboxImagePair";
+import { Button } from "@/components/ui/button";
+
+// Blog-specific MDX components — let prose handle typography,
+// only override images and custom components.
+const blogMdxComponents = {
+  img: (props: any) => (
+    <span className="not-prose block my-8 -mx-8 sm:-mx-16 md:-mx-24">
+      <Image
+        {...props}
+        width={0}
+        height={0}
+        sizes="100vw"
+        style={{ width: "100%", height: "auto", objectFit: "contain", margin: "0" }}
+        className="rounded-md"
+      />
+    </span>
+  ),
+  Image: (props: any) => (
+    <span className="not-prose block my-8 -mx-8 sm:-mx-16 md:-mx-24">
+      <Image
+        {...props}
+        className="w-full h-auto rounded-md"
+        width={800}
+        height={400}
+      />
+    </span>
+  ),
+  Button: (props: any) => <Button {...props} />,
+  SectionTitle,
+  TestimonialBox,
+  LightboxImagePair,
+  SimpleGrid: ({ children, columns = 1, col, gap = 4, ...props }: {
+    children: React.ReactNode;
+    columns?: number | string;
+    col?: number | string;
+    gap?: number | string;
+  }) => {
+    const selectedCol = col || columns;
+    const colNum = typeof selectedCol === "string" ? parseInt(selectedCol) : selectedCol;
+
+    const getGridClass = () => {
+      switch (colNum) {
+        case 1: return "grid-cols-1";
+        case 2: return "grid-cols-1 md:grid-cols-2";
+        case 3: return "grid-cols-1 md:grid-cols-3";
+        case 4: return "grid-cols-1 md:grid-cols-2 lg:grid-cols-4";
+        case 5: return "grid-cols-1 md:grid-cols-3 lg:grid-cols-5";
+        case 6: return "grid-cols-1 md:grid-cols-3 lg:grid-cols-6";
+        default: return "grid-cols-1 md:grid-cols-2";
+      }
+    };
+
+    const getGapClass = () => {
+      const gapNum = typeof gap === "string" ? parseInt(gap) : gap;
+      switch (gapNum) {
+        case 1: return "gap-1";
+        case 2: return "gap-2";
+        case 3: return "gap-3";
+        case 4: return "gap-4";
+        case 5: return "gap-5";
+        case 6: return "gap-6";
+        case 8: return "gap-8";
+        default: return "gap-4";
+      }
+    };
+
+    return (
+      <div className={cn("not-prose grid", getGridClass(), getGapClass())} {...props}>
+        {children}
+      </div>
+    );
+  },
+  GridItem: ({ children, colSpan, ...props }: {
+    children: React.ReactNode;
+    colSpan?: string | number;
+  }) => {
+    const spanNum = colSpan ? (typeof colSpan === "string" ? parseInt(colSpan) : colSpan) : 1;
+    return (
+      <div className={cn(`col-span-${spanNum}`, "flex items-center justify-center")} {...props}>
+        {children}
+      </div>
+    );
+  },
+};
+
+type BlogMDXContentProps = {
+  code: string;
+};
+
+export default function BlogMDXContent({ code }: BlogMDXContentProps) {
+  const MDXComponent = useMDXComponent(code);
+
+  return (
+    <article className={cn(
+      "prose max-w-none",
+      // Headings
+      "prose-headings:font-heading prose-headings:text-foreground prose-headings:font-bold",
+      "prose-h1:text-2xl prose-h2:text-xl prose-h3:text-lg",
+      "prose-h2:mt-10 prose-h2:mb-4 prose-h3:mt-8 prose-h3:mb-3",
+      // Body text — [&_p]/[&_li] have explicit specificity, overriding prose's inherited 1.75
+      "prose-p:text-secondarytext [&_p]:leading-[2] prose-a:text-primary-500",
+      // Links
+      "prose-a:no-underline prose-a:border-b prose-a:border-primary-500 hover:prose-a:text-primary-600",
+      // Lists
+      "prose-li:text-secondarytext [&_li]:leading-[2]",
+      // Blockquote
+      "prose-blockquote:border-l-2 prose-blockquote:border-border prose-blockquote:text-secondarytext prose-blockquote:not-italic",
+      // Code
+      "prose-code:text-foreground prose-code:before:content-none prose-code:after:content-none",
+      "prose-pre:bg-card prose-pre:border prose-pre:border-border",
+      // Images — handled by custom component above (not-prose)
+      "prose-img:rounded-md",
+      // Strong/em
+      "prose-strong:text-foreground prose-strong:font-semibold",
+      // HR
+      "prose-hr:border-border",
+      // Dark mode
+      "dark:prose-invert",
+    )}>
+      <MDXComponent components={blogMdxComponents} />
+    </article>
+  );
+}

--- a/components/PageLayout.tsx
+++ b/components/PageLayout.tsx
@@ -3,7 +3,6 @@ import dayjs from "dayjs";
 import Image from "next/image";
 import AppLayout from "@/components/AppLayout";
 import MDXContent from "@/components/mdx-components";
-import { getHeadings } from "../utils/getHeadings";
 import ScrollspyNav from "../app/[slug]/ScrollspyNav";
 
 interface PageLayoutProps {
@@ -11,8 +10,6 @@ interface PageLayoutProps {
 }
 
 export default function PageLayout({ post }: PageLayoutProps) {
-  const headings = getHeadings(post.body.raw);
-
   return (
     <AppLayout>
       <div className="min-h-screen">
@@ -31,12 +28,11 @@ export default function PageLayout({ post }: PageLayoutProps) {
           </header>
 
           {/* Page Content */}
-          <div className="prose prose-lg">
+          <article className="prose prose-lg" data-scroll-content>
             <MDXContent code={post.body.code} />
-          </div>
+          </article>
 
-          {/* Table of Contents */}
-          {headings.length > 0 && <ScrollspyNav headings={headings} />}
+          <ScrollspyNav />
 
           {/* Optional footer info for pages */}
           {post.date && (

--- a/e2e/helpers/scrollspy.ts
+++ b/e2e/helpers/scrollspy.ts
@@ -1,0 +1,274 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+import {
+  HEADING_SELECTOR,
+  SCROLL_CONTENT_SELECTOR,
+} from "../../utils/collectHeadingsFromDom";
+
+export const FIXTURE_PATH =
+  "/how-to-create-a-scroll-tracking-table-of-content-in-gatsby";
+
+export const ARTICLE_FIXTURES = [
+  {
+    path: "/learn-from-building-a-second-brain",
+    label: "short",
+  },
+  {
+    path: "/how-to-create-a-scroll-tracking-table-of-content-in-gatsby",
+    label: "long",
+  },
+  {
+    path: "/oklch-explained-for-designers",
+    label: "with-images",
+  },
+  {
+    path: "/raycast-tips-for-designers",
+    label: "raycast",
+  },
+  {
+    path: "/things-i-built-2025",
+    label: "things-built",
+  },
+  {
+    path: "/best-of-2022",
+    label: "best-of",
+  },
+] as const;
+
+export const POSITION_TOLERANCE_PX = 12;
+export const THIRD_HEADING_INDEX = 2;
+
+export type TocHeading = {
+  id: string;
+  text: string;
+};
+
+type ScrollTarget = {
+  offsetTop: number;
+  expectedScrollY: number;
+  maxScrollY: number;
+};
+
+/** Browser-side scroll math — must stay in sync with utils/scrollToHeading.ts */
+export function computeScrollTargetInPage(headingId: string): ScrollTarget | null {
+  const el = document.getElementById(headingId);
+  if (!el) return null;
+
+  const readingLine = window.innerHeight * 0.4;
+
+  let offsetTop = 0;
+  let node = el as HTMLElement;
+  while (node?.offsetParent) {
+    offsetTop += node.offsetTop;
+    node = node.offsetParent as HTMLElement;
+  }
+
+  const rectTop = el.getBoundingClientRect().top + window.scrollY;
+  const idealScroll = Math.max(
+    offsetTop - readingLine,
+    rectTop - readingLine
+  );
+  const maxScrollY = Math.max(
+    0,
+    document.documentElement.scrollHeight - window.innerHeight
+  );
+
+  return {
+    offsetTop,
+    expectedScrollY: Math.min(Math.max(0, idealScroll), maxScrollY),
+    maxScrollY,
+  };
+}
+
+export async function headingDocTop(page: Page, id: string): Promise<number> {
+  const target = await page.evaluate(computeScrollTargetInPage, id);
+  if (!target) throw new Error(`Heading #${id} not found`);
+  return target.offsetTop;
+}
+
+export function activeTocItem(page: Page): Locator {
+  return page.locator("aside nav li.active");
+}
+
+export function tocLink(page: Page, id: string): Locator {
+  return page.locator(`aside nav a[href="#${id}"]`);
+}
+
+export async function getValidTocHeadings(page: Page): Promise<TocHeading[]> {
+  return page.locator("aside nav a").evaluateAll((links) =>
+    links
+      .map((link) => ({
+        id: link.getAttribute("href")!.slice(1),
+        text: link.textContent!.trim(),
+      }))
+      .filter((heading) => document.getElementById(heading.id) !== null)
+  );
+}
+
+export async function activeTocText(page: Page): Promise<string> {
+  const item = activeTocItem(page);
+  await expect(item).toHaveCount(1);
+  return item.locator("a").innerText();
+}
+
+export async function activeTocHref(page: Page): Promise<string> {
+  const item = activeTocItem(page);
+  await expect(item).toHaveCount(1);
+  return item.locator("a").getAttribute("href") as Promise<string>;
+}
+
+export async function assertClickHighlightsTargetNotPrevious(
+  page: Page,
+  target: TocHeading,
+  previous: TocHeading
+): Promise<void> {
+  await expect(activeTocItem(page)).toHaveCount(1);
+  expect(await activeTocText(page)).toBe(target.text);
+  expect(await activeTocHref(page)).toBe(`#${target.id}`);
+  expect(await activeTocText(page)).not.toBe(previous.text);
+  expect(await activeTocHref(page)).not.toBe(`#${previous.id}`);
+}
+
+export async function waitForScrollSettle(
+  page: Page,
+  {
+    timeout = 3000,
+    stableFrames = 3,
+    startY,
+    expectMovement = false,
+  }: {
+    timeout?: number;
+    stableFrames?: number;
+    startY?: number;
+    expectMovement?: boolean;
+  } = {}
+): Promise<void> {
+  await page.waitForFunction(
+    ({ frames, initialY, mustMove }) =>
+      new Promise<boolean>((resolve) => {
+        let last = window.scrollY;
+        let stable = 0;
+        let hasMoved = !mustMove;
+
+        const tick = () => {
+          if (mustMove && Math.abs(window.scrollY - initialY) > 1) {
+            hasMoved = true;
+          }
+
+          if (window.scrollY !== last) {
+            hasMoved = true;
+            stable = 0;
+            last = window.scrollY;
+          } else if (hasMoved) {
+            stable += 1;
+          }
+
+          if (hasMoved && stable >= frames) {
+            resolve(true);
+          } else {
+            requestAnimationFrame(tick);
+          }
+        };
+
+        requestAnimationFrame(tick);
+      }),
+    {
+      frames: stableFrames,
+      initialY: startY ?? 0,
+      mustMove: expectMovement,
+    },
+    { timeout }
+  );
+}
+
+export async function scrollToReadingY(
+  page: Page,
+  targetDocTop: number
+): Promise<void> {
+  await page.evaluate((top) => {
+    const ideal = top - window.innerHeight * 0.4;
+    const maxScroll = Math.max(
+      0,
+      document.documentElement.scrollHeight - window.innerHeight
+    );
+    window.scrollTo({
+      top: Math.min(Math.max(0, ideal), maxScroll),
+      behavior: "auto",
+    });
+  }, targetDocTop);
+  await waitForScrollSettle(page);
+}
+
+async function scrollPositionError(page: Page, id: string): Promise<number> {
+  const scrollY = await page.evaluate(() => window.scrollY);
+  const target = await page.evaluate(computeScrollTargetInPage, id);
+  if (!target) return Number.POSITIVE_INFINITY;
+  return Math.abs(scrollY - target.expectedScrollY);
+}
+
+export async function clickTocLink(page: Page, id: string): Promise<void> {
+  const startY = await page.evaluate(() => window.scrollY);
+  const target = await page.evaluate(computeScrollTargetInPage, id);
+  const expectMovement = target
+    ? Math.abs(target.expectedScrollY - startY) > 1
+    : false;
+
+  await tocLink(page, id).click();
+  await waitForScrollSettle(page, {
+    timeout: 10000,
+    stableFrames: 5,
+    startY,
+    expectMovement,
+  });
+}
+
+export async function assertHeadingAtReadingLine(
+  page: Page,
+  id: string,
+  tolerance = POSITION_TOLERANCE_PX
+): Promise<void> {
+  expect(await scrollPositionError(page, id)).toBeLessThanOrEqual(tolerance);
+}
+
+export async function assertScrollTargetMath(
+  page: Page,
+  id: string,
+  tolerance = POSITION_TOLERANCE_PX
+): Promise<void> {
+  await assertHeadingAtReadingLine(page, id, tolerance);
+}
+
+export async function loadFixture(
+  page: Page,
+  path: string = FIXTURE_PATH
+): Promise<TocHeading[]> {
+  await page.goto(path);
+  await page.locator("aside nav").waitFor({ state: "visible" });
+  await page.waitForFunction(
+    ({ contentSelector, headingSelector }) => {
+      const root = document.querySelector(contentSelector);
+      return (
+        root !== null &&
+        root.querySelectorAll(headingSelector).length > 0 &&
+        document.querySelectorAll("#scrollspy-nav a").length > 0
+      );
+    },
+    {
+      contentSelector: SCROLL_CONTENT_SELECTOR,
+      headingSelector: HEADING_SELECTOR,
+    }
+  );
+  return getValidTocHeadings(page);
+}
+
+export async function waitForActiveTocStable(
+  page: Page,
+  expectedText: string,
+  durationMs = 500
+): Promise<void> {
+  const start = Date.now();
+
+  while (Date.now() - start < durationMs) {
+    expect(await activeTocText(page)).toBe(expectedText);
+    await page.waitForTimeout(50);
+  }
+}

--- a/e2e/helpers/scrollspy.ts
+++ b/e2e/helpers/scrollspy.ts
@@ -7,6 +7,12 @@ import {
 export const FIXTURE_PATH =
   "/how-to-create-a-scroll-tracking-table-of-content-in-gatsby";
 
+/** Primary regression article — long post with many headings and edge cases. */
+export const CI_ARTICLE = {
+  path: FIXTURE_PATH,
+  label: "long",
+} as const;
+
 export const ARTICLE_FIXTURES = [
   {
     path: "/learn-from-building-a-second-brain",
@@ -41,6 +47,10 @@ export type TocHeading = {
   id: string;
   text: string;
 };
+
+export function ciTag(articlePath: string): string {
+  return articlePath === CI_ARTICLE.path ? " @ci" : "";
+}
 
 type ScrollTarget = {
   offsetTop: number;

--- a/e2e/scrollspy.spec.ts
+++ b/e2e/scrollspy.spec.ts
@@ -1,0 +1,338 @@
+import { expect, test } from "@playwright/test";
+import {
+  activeTocItem,
+  activeTocHref,
+  activeTocText,
+  ARTICLE_FIXTURES,
+  assertClickHighlightsTargetNotPrevious,
+  assertHeadingAtReadingLine,
+  assertScrollTargetMath,
+  clickTocLink,
+  headingDocTop,
+  loadFixture,
+  scrollToReadingY,
+  THIRD_HEADING_INDEX,
+  tocLink,
+  waitForActiveTocStable,
+  waitForScrollSettle,
+  type TocHeading,
+} from "./helpers/scrollspy";
+
+function thirdHeading(headings: TocHeading[]): TocHeading {
+  return headings[Math.min(THIRD_HEADING_INDEX, headings.length - 1)];
+}
+
+for (const article of ARTICLE_FIXTURES) {
+  test.describe(`${article.label} — ${article.path}`, () => {
+    test.describe("Suite 1 — TOC click scrolls heading to ~40% viewport", () => {
+      let headings: TocHeading[];
+
+      test.beforeEach(async ({ page }) => {
+        headings = await loadFixture(page, article.path);
+        expect(headings.length).toBeGreaterThanOrEqual(3);
+      });
+
+      test("1.1 @smoke click middle section lands heading at reading line", async ({
+        page,
+      }) => {
+        const target = thirdHeading(headings);
+        await clickTocLink(page, target.id);
+        await assertHeadingAtReadingLine(page, target.id);
+      });
+
+      test("1.2 click last section lands heading at reading line", async ({
+        page,
+      }) => {
+        const target = headings[headings.length - 1];
+        await clickTocLink(page, target.id);
+        await assertHeadingAtReadingLine(page, target.id);
+      });
+
+      test("1.3 click first section from deep scroll", async ({ page }) => {
+        await page.evaluate(() =>
+          window.scrollTo(0, document.documentElement.scrollHeight)
+        );
+        await waitForScrollSettle(page);
+
+        const target = headings[0];
+        await clickTocLink(page, target.id);
+        await assertHeadingAtReadingLine(page, target.id);
+      });
+
+      test("1.4 jump to a distant section", async ({ page }) => {
+        test.skip(headings.length < 5, "needs at least 5 headings");
+
+        const target = headings[4];
+        await clickTocLink(page, target.id);
+        await assertHeadingAtReadingLine(page, target.id);
+      });
+
+      test("1.5 scroll target math matches implementation", async ({ page }) => {
+        const target = thirdHeading(headings);
+        await clickTocLink(page, target.id);
+        await assertScrollTargetMath(page, target.id);
+      });
+
+      test("1.N1 clicking same section twice does not drift", async ({
+        page,
+      }) => {
+        const target = thirdHeading(headings);
+        await clickTocLink(page, target.id);
+        await assertHeadingAtReadingLine(page, target.id);
+        await clickTocLink(page, target.id);
+        await assertHeadingAtReadingLine(page, target.id);
+      });
+
+      test("1.N2 rapid consecutive clicks settle on final section", async ({
+        page,
+      }) => {
+        test.skip(headings.length < 3, "needs at least 3 headings");
+
+        const middle = headings[Math.min(THIRD_HEADING_INDEX, headings.length - 1)];
+        const second = headings[1];
+
+        await tocLink(page, middle.id).click();
+        if (headings.length >= 5) {
+          await tocLink(page, headings[4].id).click();
+        }
+        const beforeFinalY = await page.evaluate(() => window.scrollY);
+        await tocLink(page, second.id).click();
+        await waitForScrollSettle(page, {
+          timeout: 10000,
+          stableFrames: 5,
+          startY: beforeFinalY,
+          expectMovement: true,
+        });
+
+        await assertHeadingAtReadingLine(page, second.id);
+      });
+    });
+
+    test.describe("Suite 2 — Highlight matches clicked TOC item", () => {
+      let headings: TocHeading[];
+
+      test.beforeEach(async ({ page }) => {
+        headings = await loadFixture(page, article.path);
+      });
+
+      test("2.1 @smoke click middle section highlights correctly", async ({
+        page,
+      }) => {
+        const target = thirdHeading(headings);
+        await clickTocLink(page, target.id);
+        expect(await activeTocText(page)).toBe(target.text);
+      });
+
+      test("2.R1 @smoke @regression click third heading scrolls and highlights third not second", async ({
+        page,
+      }) => {
+        test.skip(
+          headings.length <= THIRD_HEADING_INDEX,
+          "needs at least 3 headings"
+        );
+
+        const previous = headings[THIRD_HEADING_INDEX - 1];
+        const target = headings[THIRD_HEADING_INDEX];
+
+        await clickTocLink(page, target.id);
+        await assertHeadingAtReadingLine(page, target.id);
+        await assertClickHighlightsTargetNotPrevious(page, target, previous);
+      });
+
+      test("2.2 clicking every TOC item highlights the clicked item", async ({
+        page,
+      }) => {
+        for (const heading of headings) {
+          await clickTocLink(page, heading.id);
+          expect(await activeTocText(page)).toBe(heading.text);
+        }
+      });
+
+      test("2.3 click earlier section from a later section", async ({
+        page,
+      }) => {
+        test.skip(headings.length < 4, "needs at least 4 headings");
+
+        const later = headings[headings.length - 1];
+        const earlier = thirdHeading(headings);
+
+        await scrollToReadingY(page, await headingDocTop(page, later.id));
+        await clickTocLink(page, earlier.id);
+        expect(await activeTocText(page)).toBe(earlier.text);
+      });
+
+      test("2.4 active link href matches highlighted item", async ({ page }) => {
+        const target = headings[Math.min(3, headings.length - 1)];
+        await clickTocLink(page, target.id);
+        expect(await activeTocHref(page)).toBe(`#${target.id}`);
+      });
+
+      test("2.5 only one TOC item is highlighted", async ({ page }) => {
+        const target = headings[Math.min(2, headings.length - 1)];
+        await clickTocLink(page, target.id);
+        await expect(activeTocItem(page)).toHaveCount(1);
+      });
+
+      test("2.T1 @smoke highlight is correct only after scroll settles", async ({
+        page,
+      }) => {
+        const target = thirdHeading(headings);
+        await clickTocLink(page, target.id);
+        expect(await activeTocText(page)).toBe(target.text);
+      });
+
+      test("2.T2 active highlight stays stable after settle", async ({
+        page,
+      }) => {
+        const target = headings[Math.min(3, headings.length - 1)];
+        await clickTocLink(page, target.id);
+        await waitForActiveTocStable(page, target.text);
+      });
+    });
+
+    test.describe("Suite 3 — Scroll-driven highlight tracks visible section", () => {
+      let headings: TocHeading[];
+
+      test.beforeEach(async ({ page }) => {
+        headings = await loadFixture(page, article.path);
+      });
+
+      test("3.1 @smoke initial load highlights first section", async ({
+        page,
+      }) => {
+        expect(await activeTocText(page)).toBe(headings[0].text);
+      });
+
+      test("3.2 walk through all sections downward", async ({ page }) => {
+        for (const heading of headings) {
+          await scrollToReadingY(page, await headingDocTop(page, heading.id));
+          expect(await activeTocText(page)).toBe(heading.text);
+        }
+      });
+
+      test("3.3 walk upward through sections", async ({ page }) => {
+        await page.evaluate(() =>
+          window.scrollTo(0, document.documentElement.scrollHeight)
+        );
+        await waitForScrollSettle(page);
+
+        for (let i = headings.length - 1; i >= 0; i -= 1) {
+          await scrollToReadingY(
+            page,
+            await headingDocTop(page, headings[i].id)
+          );
+          expect(await activeTocText(page)).toBe(headings[i].text);
+        }
+      });
+
+      test("3.4 boundary switches active section at reading line", async ({
+        page,
+      }) => {
+        test.skip(headings.length < 4, "needs at least 4 headings");
+
+        const index = 3;
+        const previous = headings[index - 1];
+        const current = headings[index];
+        const currentTop = await headingDocTop(page, current.id);
+
+        await scrollToReadingY(page, currentTop - 1);
+        expect(await activeTocText(page)).toBe(previous.text);
+
+        await scrollToReadingY(page, currentTop);
+        expect(await activeTocText(page)).toBe(current.text);
+      });
+
+      test("3.5 last section stays active at page bottom", async ({ page }) => {
+        await page.evaluate(() =>
+          window.scrollTo(0, document.documentElement.scrollHeight)
+        );
+        await waitForScrollSettle(page);
+
+        const last = headings[headings.length - 1];
+        expect(await activeTocText(page)).toBe(last.text);
+      });
+
+      test("3.6 slow continuous scroll increases active index monotonically", async ({
+        page,
+      }) => {
+        test.skip(headings.length < 3, "needs at least 3 headings");
+
+        const observedIndexes: number[] = [];
+        let lastIndex = -1;
+
+        await page.evaluate(() => window.scrollTo(0, 0));
+        await waitForScrollSettle(page);
+
+        for (let step = 0; step < 40; step += 1) {
+          await page.mouse.wheel(0, 250);
+          await page.waitForTimeout(80);
+
+          const activeText = await activeTocText(page);
+          const index = headings.findIndex(
+            (heading) => heading.text === activeText
+          );
+          expect(index).toBeGreaterThanOrEqual(0);
+
+          if (index !== lastIndex) {
+            if (lastIndex >= 0) {
+              expect(index).toBeGreaterThan(lastIndex);
+            }
+            observedIndexes.push(index);
+            lastIndex = index;
+          }
+        }
+
+        expect(observedIndexes.length).toBeGreaterThan(0);
+      });
+
+      test("3.P1 @smoke programmatic scroll highlights matching section", async ({
+        page,
+      }) => {
+        for (const heading of headings) {
+          await scrollToReadingY(
+            page,
+            await headingDocTop(page, heading.id)
+          );
+          expect(await activeTocText(page)).toBe(heading.text);
+        }
+      });
+    });
+
+    test.describe("Suite 4 — Cross-cutting resilience", () => {
+      test("4.1 viewport resize keeps active section and click behavior", async ({
+        page,
+      }) => {
+        test.skip(
+          article.path !==
+            "/how-to-create-a-scroll-tracking-table-of-content-in-gatsby",
+          "resize scenario needs 6+ headings"
+        );
+
+        const headings = await loadFixture(page, article.path);
+        const section4 = headings[3];
+        const section6 = headings[5];
+
+        await scrollToReadingY(page, await headingDocTop(page, section4.id));
+        expect(await activeTocText(page)).toBe(section4.text);
+
+        await page.setViewportSize({ width: 1400, height: 900 });
+        await page.waitForTimeout(250);
+
+        expect(await activeTocText(page)).toBe(section4.text);
+
+        await clickTocLink(page, section6.id);
+        await assertHeadingAtReadingLine(page, section6.id);
+      });
+    });
+  });
+}
+
+test.describe("Suite 4 — Global", () => {
+  test("4.2 TOC hidden below xl breakpoint", async ({ page }) => {
+    await page.setViewportSize({ width: 1024, height: 900 });
+    await page.goto(
+      "/how-to-create-a-scroll-tracking-table-of-content-in-gatsby"
+    );
+    await expect(page.locator("aside nav")).toBeHidden();
+  });
+});

--- a/e2e/scrollspy.spec.ts
+++ b/e2e/scrollspy.spec.ts
@@ -7,6 +7,7 @@ import {
   assertClickHighlightsTargetNotPrevious,
   assertHeadingAtReadingLine,
   assertScrollTargetMath,
+  ciTag,
   clickTocLink,
   headingDocTop,
   loadFixture,
@@ -32,7 +33,7 @@ for (const article of ARTICLE_FIXTURES) {
         expect(headings.length).toBeGreaterThanOrEqual(3);
       });
 
-      test("1.1 @smoke click middle section lands heading at reading line", async ({
+      test(`1.1 @smoke${ciTag(article.path)} click middle section lands heading at reading line`, async ({
         page,
       }) => {
         const target = thirdHeading(headings);
@@ -115,7 +116,7 @@ for (const article of ARTICLE_FIXTURES) {
         headings = await loadFixture(page, article.path);
       });
 
-      test("2.1 @smoke click middle section highlights correctly", async ({
+      test(`2.1 @smoke${ciTag(article.path)} click middle section highlights correctly`, async ({
         page,
       }) => {
         const target = thirdHeading(headings);
@@ -123,7 +124,7 @@ for (const article of ARTICLE_FIXTURES) {
         expect(await activeTocText(page)).toBe(target.text);
       });
 
-      test("2.R1 @smoke @regression click third heading scrolls and highlights third not second", async ({
+      test(`2.R1 @smoke @regression${ciTag(article.path)} click third heading scrolls and highlights third not second`, async ({
         page,
       }) => {
         test.skip(
@@ -173,7 +174,7 @@ for (const article of ARTICLE_FIXTURES) {
         await expect(activeTocItem(page)).toHaveCount(1);
       });
 
-      test("2.T1 @smoke highlight is correct only after scroll settles", async ({
+      test(`2.T1 @smoke${ciTag(article.path)} highlight is correct only after scroll settles`, async ({
         page,
       }) => {
         const target = thirdHeading(headings);
@@ -197,7 +198,7 @@ for (const article of ARTICLE_FIXTURES) {
         headings = await loadFixture(page, article.path);
       });
 
-      test("3.1 @smoke initial load highlights first section", async ({
+      test(`3.1 @smoke${ciTag(article.path)} initial load highlights first section`, async ({
         page,
       }) => {
         expect(await activeTocText(page)).toBe(headings[0].text);
@@ -285,7 +286,7 @@ for (const article of ARTICLE_FIXTURES) {
         expect(observedIndexes.length).toBeGreaterThan(0);
       });
 
-      test("3.P1 @smoke programmatic scroll highlights matching section", async ({
+      test(`3.P1 @smoke${ciTag(article.path)} programmatic scroll highlights matching section`, async ({
         page,
       }) => {
         for (const heading of headings) {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@chakra-ui/icons": "^2.1.1",
     "@chakra-ui/react": "^2.8.2",
+    "@chenglou/pretext": "^0.0.7",
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
     "@fontsource/chivo": "^5.0.8",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "postbuild": "next-sitemap",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "test:e2e:smoke": "playwright test --grep @smoke"
+    "test:e2e:smoke": "playwright test --grep @smoke",
+    "test:e2e:ci": "playwright test --grep @ci"
   },
   "dependencies": {
     "@chakra-ui/icons": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "start": "next start",
     "lint": "next lint",
     "build:content": "contentlayer2 build",
-    "postbuild": "next-sitemap"
+    "postbuild": "next-sitemap",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:smoke": "playwright test --grep @smoke"
   },
   "dependencies": {
     "@chakra-ui/icons": "^2.1.1",
@@ -18,6 +21,7 @@
     "@emotion/styled": "^11.11.0",
     "@fontsource/chivo": "^5.0.8",
     "@fontsource/space-grotesk": "^5.0.8",
+    "@fsegurai/scrollspy": "^2.0.0",
     "@jsdevtools/rehype-toc": "^3.0.2",
     "@next/third-parties": "^15.5.6",
     "@radix-ui/react-slot": "^1.2.3",
@@ -53,6 +57,7 @@
     "typescript-array-utils": "^0.1.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@types/github-slugger": "^1.3.0",
     "@types/lodash.kebabcase": "^4.1.7",
     "@types/node": "^20.11.24",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "website-v3",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@10.6.2",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const E2E_PORT = 3001;
+const E2E_BASE_URL = `http://localhost:${E2E_PORT}`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: E2E_BASE_URL,
+    trace: "on-first-retry",
+    viewport: { width: 1280, height: 900 },
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: `pnpm build:content && PORT=${E2E_PORT} pnpm dev`,
+    url: E2E_BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,9 +65,6 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
-      gsap:
-        specifier: ^3.15.0
-        version: 3.15.0
       lucide-react:
         specifier: ^0.525.0
         version: 0.525.0(react@18.3.1)
@@ -2160,9 +2157,6 @@ packages:
   gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
-
-  gsap@3.15.0:
-    resolution: {integrity: sha512-dMW4CWBTUK1AEEDeZc1g4xpPGIrSf9fJF960qbTZmN/QwZIWY5wgliS6JWl9/25fpTGJrMRtSjGtOmPnfjZB+A==}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -5911,8 +5905,6 @@ snapshots:
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
-
-  gsap@3.15.0: {}
 
   has-bigints@1.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,12 +29,15 @@ importers:
       '@fontsource/space-grotesk':
         specifier: ^5.0.8
         version: 5.2.8
+      '@fsegurai/scrollspy':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@jsdevtools/rehype-toc':
         specifier: ^3.0.2
         version: 3.0.2
       '@next/third-parties':
         specifier: ^15.5.6
-        version: 15.5.6(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 15.5.6(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@18.3.23)(react@18.3.1)
@@ -46,7 +49,7 @@ importers:
         version: 0.5.16(tailwindcss@4.1.11)
       '@vercel/analytics':
         specifier: ^1.1.1
-        version: 1.5.0(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 1.5.0(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       airtable:
         specifier: ^0.12.2
         version: 0.12.2
@@ -62,18 +65,21 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
+      gsap:
+        specifier: ^3.15.0
+        version: 3.15.0
       lucide-react:
         specifier: ^0.525.0
         version: 0.525.0(react@18.3.1)
       next:
         specifier: ^15.5.7
-        version: 15.5.7(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-contentlayer2:
         specifier: ^0.4.6
-        version: 0.4.6(acorn@8.15.0)(contentlayer2@0.4.6(acorn@8.15.0)(esbuild@0.20.2))(esbuild@0.20.2)(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 0.4.6(acorn@8.15.0)(contentlayer2@0.4.6(acorn@8.15.0)(esbuild@0.20.2))(esbuild@0.20.2)(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-seo:
         specifier: ^6.4.0
-        version: 6.8.0(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 6.8.0(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
@@ -129,6 +135,9 @@ importers:
         specifier: ^0.1.4
         version: 0.1.4
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@types/github-slugger':
         specifier: ^1.3.0
         version: 1.3.0
@@ -167,7 +176,7 @@ importers:
         version: 7.7.12(react@18.3.1)
       next-sitemap:
         specifier: ^4.2.3
-        version: 4.2.3(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 4.2.3(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       rehype-autolink-headings:
         specifier: ^7.1.0
         version: 7.1.0
@@ -590,6 +599,9 @@ packages:
   '@fontsource/space-grotesk@5.2.8':
     resolution: {integrity: sha512-8rlIzpX+lo36y0g77OlwjeBj2DPo9XOwrzqKRLHYZcWcsj73SlkVI6UdXxDCZGLO7oQti1q9QPXzMBYbzSz60w==}
 
+  '@fsegurai/scrollspy@2.0.0':
+    resolution: {integrity: sha512-UFt3i63CQqMmP8dVyNn1ATxt/yq+baBkmqxVfbRISloVhv1lXsD3KObSSNu3T127K9n+jK/kHUIMcFpcs/1o0g==}
+
   '@grpc/grpc-js@1.13.4':
     resolution: {integrity: sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==}
     engines: {node: '>=12.10.0'}
@@ -645,92 +657,78 @@ packages:
     resolution: {integrity: sha512-RXwd0CgG+uPRX5YYrkzKyalt2OJYRiJQ8ED/fi1tq9WQW2jsQIn0tqrlR5l5dr/rjqq6AHAxURhj2DVjyQWSOA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.0':
     resolution: {integrity: sha512-mWd2uWvDtL/nvIzThLq3fr2nnGfyr/XMXlq8ZJ9WMR6PXijHlC3ksp0IpuhK6bougvQrchUAfzRLnbsen0Cqvw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.0':
     resolution: {integrity: sha512-Xod/7KaDDHkYu2phxxfeEPXfVXFKx70EAFZ0qyUdOjCcxbjqyJOEUpDe6RIyaunGxT34Anf9ue/wuWOqBW2WcQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.0':
     resolution: {integrity: sha512-eMKfzDxLGT8mnmPJTNMcjfO33fLiTDsrMlUVcp6b96ETbnJmd4uvZxVJSKPQfS+odwfVaGifhsB07J1LynFehw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.0':
     resolution: {integrity: sha512-ZW3FPWIc7K1sH9E3nxIGB3y3dZkpJlMnkk7z5tu1nSkBoCgw2nSRTFHI5pB/3CQaJM0pdzMF3paf9ckKMSE9Tg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.0':
     resolution: {integrity: sha512-UG+LqQJbf5VJ8NWJ5Z3tdIe/HXjuIdo4JeVNADXBFuG7z9zjoegpzzGIyV5zQKi4zaJjnAd2+g2nna8TZvuW9Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.0':
     resolution: {integrity: sha512-SRYOLR7CXPgNze8akZwjoGBoN1ThNZoqpOgfnOxmWsklTGVfJiGJoC/Lod7aNMGA1jSsKWM1+HRX43OP6p9+6Q==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.3':
     resolution: {integrity: sha512-QdrKe3EvQrqwkDrtuTIjI0bu6YEJHTgEeqdzI3uWJOH6G1O8Nl1iEeVYRGdj1h5I21CqxSvQp1Yv7xeU3ZewbA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.3':
     resolution: {integrity: sha512-oBK9l+h6KBN0i3dC8rYntLiVfW8D8wH+NPNT3O/WBHeW0OQWCjfWksLUaPidsrDKpJgXp3G3/hkmhptAW0I3+A==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.3':
     resolution: {integrity: sha512-GLtbLQMCNC5nxuImPR2+RgrviwKwVql28FWZIW1zWruy6zLgA5/x2ZXk3mxj58X/tszVF69KK0Is83V8YgWhLA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.3':
     resolution: {integrity: sha512-3gahT+A6c4cdc2edhsLHmIOXMb17ltffJlxR0aC2VPZfwKoTGZec6u5GrFgdR7ciJSsHT27BD3TIuGcuRT0KmQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.3':
     resolution: {integrity: sha512-8kYso8d806ypnSq3/Ly0QEw90V5ZoHh10yH0HnrzOCr6DKAPI6QVHvwleqMkVQ0m+fc7EH8ah0BB0QPuWY6zJQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.3':
     resolution: {integrity: sha512-vAjbHDlr4izEiXM1OTggpCcPg9tn4YriK5vAjowJsHwdBIdx0fYRsURkxLG2RLm9gyBq66gwtWI8Gx0/ov+JKQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.3':
     resolution: {integrity: sha512-gCWUn9547K5bwvOn9l5XGAEjVTTRji4aPTqLzGXHvIr6bIDZKNTA34seMPgM0WmSf+RYBH411VavCejp3PkOeQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.3':
     resolution: {integrity: sha512-+CyRcpagHMGteySaWos8IbnXcHgfDn7pO2fiC2slJxvNq9gDipYBN42/RagzctVRKgxATmfqOSulgZv5e1RdMg==}
@@ -838,28 +836,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.7':
     resolution: {integrity: sha512-nfymt+SE5cvtTrG9u1wdoxBr9bVB7mtKTcj0ltRn6gkP/2Nu1zM5ei8rwP9qKQP0Y//umK+TtkKgNtfboBxRrw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.7':
     resolution: {integrity: sha512-hvXcZvCaaEbCZcVzcY7E1uXN9xWZfFvkNHwbe/n4OkRhFWrs1J1QV+4U1BN06tXLdaS4DazEGXwgqnu/VMcmqw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.7':
     resolution: {integrity: sha512-4IUO539b8FmF0odY6/SqANJdgwn1xs1GkPO5doZugwZ3ETF6JUdckk7RGmsfSf7ws8Qb2YB5It33mvNL/0acqA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.7':
     resolution: {integrity: sha512-CpJVTkYI3ZajQkC5vajM7/ApKJUOlm6uP4BknM3XKvJ7VXAvCqSjSLmM0LKdYzn6nBJVSjdclx8nYJSa3xlTgQ==}
@@ -1012,6 +1006,11 @@ packages:
     resolution: {integrity: sha512-TtxJSRD8Ohxp6bKkhrm27JRHAxPczQA7idtcTOMYI+wQRRrfgqxHv1cFbCApcSnNjtXkmzFozn6jQtFrOmbjPQ==}
     engines: {node: '>=14'}
 
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
@@ -1110,28 +1109,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.11':
     resolution: {integrity: sha512-m/NVRFNGlEHJrNVk3O6I9ggVuNjXHIPoD6bqay/pubtYC9QIdAMpS+cswZQPBLvVvEF6GtSNONbDkZrjWZXYNQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.11':
     resolution: {integrity: sha512-YW6sblI7xukSD2TdbbaeQVDysIm/UPJtObHJHKxDEcW2exAtY47j52f8jZXkqE1krdnkhCMGqP3dbniu1Te2Fg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.11':
     resolution: {integrity: sha512-e3C/RRhGunWYNC3aSF7exsQkdXzQ/M+aYuZHKnw4U7KQwTJotnWsGOIVih0s2qQzmEzOFIJ3+xt7iq67K/p56Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.11':
     resolution: {integrity: sha512-Xo1+/GU0JEN/C/dvcammKHzeM6NqKovG+6921MR6oadee5XPBaKOumrJCXvopJ/Qb5TH7LX/UAywbqrP4lax0g==}
@@ -1353,49 +1348,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2095,6 +2082,11 @@ packages:
   framesync@6.1.2:
     resolution: {integrity: sha512-jBTqhX6KaQVDyus8muwZbBeGGP0XgujBRbQ7gM7BRdS3CadCZIHiawyzYLnafYcvZIh5j8WE7cxZKFn7dXhu9g==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2168,6 +2160,9 @@ packages:
   gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
+
+  gsap@3.15.0:
+    resolution: {integrity: sha512-dMW4CWBTUK1AEEDeZc1g4xpPGIrSf9fJF960qbTZmN/QwZIWY5wgliS6JWl9/25fpTGJrMRtSjGtOmPnfjZB+A==}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -2524,28 +2519,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -3015,6 +3006,16 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -4211,6 +4212,8 @@ snapshots:
 
   '@fontsource/space-grotesk@5.2.8': {}
 
+  '@fsegurai/scrollspy@2.0.0': {}
+
   '@grpc/grpc-js@1.13.4':
     dependencies:
       '@grpc/proto-loader': 0.7.15
@@ -4446,9 +4449,9 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.7':
     optional: true
 
-  '@next/third-parties@15.5.6(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@next/third-parties@15.5.6(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:
-      next: 15.5.7(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       third-party-capital: 1.0.20
 
@@ -4584,6 +4587,10 @@ snapshots:
   '@opentelemetry/semantic-conventions@1.28.0': {}
 
   '@opentelemetry/semantic-conventions@1.36.0': {}
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
 
   '@popperjs/core@2.11.8': {}
 
@@ -4945,9 +4952,9 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/analytics@1.5.0(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@vercel/analytics@1.5.0(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     optionalDependencies:
-      next: 15.5.7(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
 
   '@zag-js/dom-query@0.31.1': {}
@@ -5822,6 +5829,9 @@ snapshots:
     dependencies:
       tslib: 2.4.0
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5901,6 +5911,8 @@ snapshots:
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
+
+  gsap@3.15.0: {}
 
   has-bigints@1.1.0: {}
 
@@ -6873,12 +6885,12 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next-contentlayer2@0.4.6(acorn@8.15.0)(contentlayer2@0.4.6(acorn@8.15.0)(esbuild@0.20.2))(esbuild@0.20.2)(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next-contentlayer2@0.4.6(acorn@8.15.0)(contentlayer2@0.4.6(acorn@8.15.0)(esbuild@0.20.2))(esbuild@0.20.2)(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@contentlayer2/core': 0.4.3(acorn@8.15.0)(esbuild@0.20.2)
       '@contentlayer2/utils': 0.4.3
       contentlayer2: 0.4.6(acorn@8.15.0)(esbuild@0.20.2)
-      next: 15.5.7(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
@@ -6888,21 +6900,21 @@ snapshots:
       - markdown-wasm
       - supports-color
 
-  next-seo@6.8.0(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next-seo@6.8.0(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      next: 15.5.7(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  next-sitemap@4.2.3(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+  next-sitemap@4.2.3(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
       '@corex/deepmerge': 4.0.43
       '@next/env': 13.5.11
       fast-glob: 3.3.3
       minimist: 1.2.8
-      next: 15.5.7(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 15.5.7
       '@swc/helpers': 0.5.15
@@ -6921,6 +6933,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 15.5.7
       '@next/swc-win32-x64-msvc': 15.5.7
       '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.60.0
       sharp: 0.34.3
     transitivePeerDependencies:
       - '@babel/core'
@@ -7047,6 +7060,14 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@chakra-ui/react':
         specifier: ^2.8.2
         version: 2.10.9(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(framer-motion@12.23.12(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@chenglou/pretext':
+        specifier: ^0.0.7
+        version: 0.0.7
       '@emotion/react':
         specifier: ^11.11.3
         version: 11.14.0(@types/react@18.3.23)(react@18.3.1)
@@ -273,6 +276,9 @@ packages:
     resolution: {integrity: sha512-KTBCK+M5KtXH6p54XS39ImQUMVtAx65BoZDoEms3LuObyTo1+civ1sMm4h3nRT320U6H5H7D35WnABVQjqU/4g==}
     peerDependencies:
       react: '>=16.8.0'
+
+  '@chenglou/pretext@0.0.7':
+    resolution: {integrity: sha512-FV5hj3fGqpBlzbANUbR+s+6XuNRrghVVyuNs33zdH2SzU7MvK+7GlW6xREjDCreixKbexEn7OEkDgAFeWuu5Hg==}
 
   '@contentlayer2/cli@0.4.3':
     resolution: {integrity: sha512-ZJ+Iiu2rVI50x60XoqnrsO/Q8eqFX5AlP1L0U/3ygaAas3tnOqTzQZ1UsxYQMpJzcLok24ddlhKfQKbCMUJPiQ==}
@@ -639,78 +645,92 @@ packages:
     resolution: {integrity: sha512-RXwd0CgG+uPRX5YYrkzKyalt2OJYRiJQ8ED/fi1tq9WQW2jsQIn0tqrlR5l5dr/rjqq6AHAxURhj2DVjyQWSOA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.0':
     resolution: {integrity: sha512-mWd2uWvDtL/nvIzThLq3fr2nnGfyr/XMXlq8ZJ9WMR6PXijHlC3ksp0IpuhK6bougvQrchUAfzRLnbsen0Cqvw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.0':
     resolution: {integrity: sha512-Xod/7KaDDHkYu2phxxfeEPXfVXFKx70EAFZ0qyUdOjCcxbjqyJOEUpDe6RIyaunGxT34Anf9ue/wuWOqBW2WcQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.0':
     resolution: {integrity: sha512-eMKfzDxLGT8mnmPJTNMcjfO33fLiTDsrMlUVcp6b96ETbnJmd4uvZxVJSKPQfS+odwfVaGifhsB07J1LynFehw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.0':
     resolution: {integrity: sha512-ZW3FPWIc7K1sH9E3nxIGB3y3dZkpJlMnkk7z5tu1nSkBoCgw2nSRTFHI5pB/3CQaJM0pdzMF3paf9ckKMSE9Tg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.0':
     resolution: {integrity: sha512-UG+LqQJbf5VJ8NWJ5Z3tdIe/HXjuIdo4JeVNADXBFuG7z9zjoegpzzGIyV5zQKi4zaJjnAd2+g2nna8TZvuW9Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.0':
     resolution: {integrity: sha512-SRYOLR7CXPgNze8akZwjoGBoN1ThNZoqpOgfnOxmWsklTGVfJiGJoC/Lod7aNMGA1jSsKWM1+HRX43OP6p9+6Q==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.3':
     resolution: {integrity: sha512-QdrKe3EvQrqwkDrtuTIjI0bu6YEJHTgEeqdzI3uWJOH6G1O8Nl1iEeVYRGdj1h5I21CqxSvQp1Yv7xeU3ZewbA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.3':
     resolution: {integrity: sha512-oBK9l+h6KBN0i3dC8rYntLiVfW8D8wH+NPNT3O/WBHeW0OQWCjfWksLUaPidsrDKpJgXp3G3/hkmhptAW0I3+A==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.3':
     resolution: {integrity: sha512-GLtbLQMCNC5nxuImPR2+RgrviwKwVql28FWZIW1zWruy6zLgA5/x2ZXk3mxj58X/tszVF69KK0Is83V8YgWhLA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.3':
     resolution: {integrity: sha512-3gahT+A6c4cdc2edhsLHmIOXMb17ltffJlxR0aC2VPZfwKoTGZec6u5GrFgdR7ciJSsHT27BD3TIuGcuRT0KmQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.3':
     resolution: {integrity: sha512-8kYso8d806ypnSq3/Ly0QEw90V5ZoHh10yH0HnrzOCr6DKAPI6QVHvwleqMkVQ0m+fc7EH8ah0BB0QPuWY6zJQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.3':
     resolution: {integrity: sha512-vAjbHDlr4izEiXM1OTggpCcPg9tn4YriK5vAjowJsHwdBIdx0fYRsURkxLG2RLm9gyBq66gwtWI8Gx0/ov+JKQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.3':
     resolution: {integrity: sha512-gCWUn9547K5bwvOn9l5XGAEjVTTRji4aPTqLzGXHvIr6bIDZKNTA34seMPgM0WmSf+RYBH411VavCejp3PkOeQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.3':
     resolution: {integrity: sha512-+CyRcpagHMGteySaWos8IbnXcHgfDn7pO2fiC2slJxvNq9gDipYBN42/RagzctVRKgxATmfqOSulgZv5e1RdMg==}
@@ -818,24 +838,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.7':
     resolution: {integrity: sha512-nfymt+SE5cvtTrG9u1wdoxBr9bVB7mtKTcj0ltRn6gkP/2Nu1zM5ei8rwP9qKQP0Y//umK+TtkKgNtfboBxRrw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.7':
     resolution: {integrity: sha512-hvXcZvCaaEbCZcVzcY7E1uXN9xWZfFvkNHwbe/n4OkRhFWrs1J1QV+4U1BN06tXLdaS4DazEGXwgqnu/VMcmqw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.7':
     resolution: {integrity: sha512-4IUO539b8FmF0odY6/SqANJdgwn1xs1GkPO5doZugwZ3ETF6JUdckk7RGmsfSf7ws8Qb2YB5It33mvNL/0acqA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.7':
     resolution: {integrity: sha512-CpJVTkYI3ZajQkC5vajM7/ApKJUOlm6uP4BknM3XKvJ7VXAvCqSjSLmM0LKdYzn6nBJVSjdclx8nYJSa3xlTgQ==}
@@ -1086,24 +1110,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.11':
     resolution: {integrity: sha512-m/NVRFNGlEHJrNVk3O6I9ggVuNjXHIPoD6bqay/pubtYC9QIdAMpS+cswZQPBLvVvEF6GtSNONbDkZrjWZXYNQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.11':
     resolution: {integrity: sha512-YW6sblI7xukSD2TdbbaeQVDysIm/UPJtObHJHKxDEcW2exAtY47j52f8jZXkqE1krdnkhCMGqP3dbniu1Te2Fg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.11':
     resolution: {integrity: sha512-e3C/RRhGunWYNC3aSF7exsQkdXzQ/M+aYuZHKnw4U7KQwTJotnWsGOIVih0s2qQzmEzOFIJ3+xt7iq67K/p56Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.11':
     resolution: {integrity: sha512-Xo1+/GU0JEN/C/dvcammKHzeM6NqKovG+6921MR6oadee5XPBaKOumrJCXvopJ/Qb5TH7LX/UAywbqrP4lax0g==}
@@ -1325,41 +1353,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2488,24 +2524,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -3819,6 +3859,8 @@ snapshots:
       '@types/lodash.mergewith': 4.6.9
       lodash.mergewith: 4.6.2
       react: 18.3.1
+
+  '@chenglou/pretext@0.0.7': {}
 
   '@contentlayer2/cli@0.4.3(acorn@8.15.0)(esbuild@0.20.2)':
     dependencies:

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "./theme.css";
+@plugin "@tailwindcss/typography";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -11,6 +11,7 @@
     "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
   --font-body: var(--font-public-sans), -apple-system, BlinkMacSystemFont,
     "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+  --font-mono: var(--font-space-mono), ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas, monospace;
 
   /* Colors - Primary Palette */
   --color-primary-100: oklch(97% 0.0148 238.24);

--- a/utils/collectHeadingsFromDom.ts
+++ b/utils/collectHeadingsFromDom.ts
@@ -1,0 +1,32 @@
+export type DomHeading = {
+  id: string;
+  text: string;
+  level: number;
+};
+
+export const SCROLL_CONTENT_SELECTOR = "[data-scroll-content]";
+export const HEADING_SELECTOR = "h2[id], h3[id]";
+
+export function collectHeadingsFromDom(
+  root: ParentNode,
+  selector = HEADING_SELECTOR
+): DomHeading[] {
+  return [...root.querySelectorAll(selector)]
+    .filter(
+      (element) =>
+        !element.closest("pre") &&
+        !element.closest("code") &&
+        Boolean(element.id)
+    )
+    .map((element) => ({
+      id: element.id,
+      text: element.textContent?.trim() ?? "",
+      level: Number(element.tagName.charAt(1)),
+    }));
+}
+
+export function getScrollContentRoot(
+  selector = SCROLL_CONTENT_SELECTOR
+): Element | null {
+  return document.querySelector(selector);
+}

--- a/utils/getHeadings.ts
+++ b/utils/getHeadings.ts
@@ -1,42 +1,26 @@
-import GithubSlugger from 'github-slugger'
+import GithubSlugger from "github-slugger";
 
 type Heading = {
   text: string;
   level: number;
   id: string;
-}
+};
 
 export function getHeadings(markdown: string): Heading[] {
-   
-  // Split the Markdown input into an array of lines
   const lines = markdown.split("\n");
-
-  // Filter the lines to include only those that start with a hash character (#)
   const headings = lines.filter((line) => line.startsWith("#"));
-
-  // Initialize an empty array to hold the results
   const result: Heading[] = [];
+  const slugger = new GithubSlugger();
 
-  // Loop over each heading line
-  for (let i = 0; i < headings.length; i++) {
-    const line = headings[i];
-
-    // Use a regular expression to count the number of hash characters at the beginning of the line,
-    // which indicates the heading level
+  for (const line of headings) {
     const level = line.match(/#+/g)?.[0].length || 0;
+    const text = line
+      .replace(/#+\s+/g, "")
+      .replace(/\[(.*?)\]\(.*?\)/g, "$1")
+      .trim();
 
-    // Use another regular expression to remove the hash characters and any leading whitespace,
-    // as well as any Markdown links enclosed in square brackets and parentheses
-    const text = line.replace(/#+\s+/g, "").replace(/\[(.*?)\]\(.*?\)/g, "$1");
-
-    const slugger = new GithubSlugger()
-    // Slugger the text
-    
-    const id = slugger.slug(text);
-    // Add the result to the array
-    result.push({ text, level, id });
+    result.push({ text, level, id: slugger.slug(text) });
   }
 
-  // Return the array of results
   return result;
-} 
+}

--- a/utils/scrollToHeading.ts
+++ b/utils/scrollToHeading.ts
@@ -1,0 +1,47 @@
+export const readingLineOffset = () => window.innerHeight * 0.4;
+
+/** Matches @fsegurai/scrollspy getOffsetTop — keeps scroll + highlight in sync. */
+export function getOffsetTop(element: Element): number {
+  let top = 0;
+  let node = element as HTMLElement;
+
+  while (node?.offsetParent) {
+    top += node.offsetTop;
+    node = node.offsetParent as HTMLElement;
+  }
+
+  return top;
+}
+
+export function getMaxScrollY(): number {
+  return Math.max(
+    0,
+    document.documentElement.scrollHeight - window.innerHeight
+  );
+}
+
+function getIdealScrollTop(element: Element): number {
+  const reading = readingLineOffset();
+  const offsetTopIdeal = getOffsetTop(element) - reading;
+  const rectTop = element.getBoundingClientRect().top + window.scrollY;
+  const rectIdeal = rectTop - reading;
+  return Math.max(offsetTopIdeal, rectIdeal);
+}
+
+export function getScrollTopForHeading(element: Element): number {
+  const idealTop = getIdealScrollTop(element);
+  return Math.min(Math.max(0, idealTop), getMaxScrollY());
+}
+
+export function scrollToHeadingAtReadingLine(
+  element: Element,
+  behavior: ScrollBehavior = "smooth"
+): number {
+  const top = getScrollTopForHeading(element);
+  const distance = Math.abs(top - window.scrollY);
+  const effectiveBehavior =
+    distance > window.innerHeight * 2 ? "auto" : behavior;
+
+  window.scrollTo({ top, behavior: effectiveBehavior });
+  return top;
+}

--- a/utils/waitForScrollEnd.ts
+++ b/utils/waitForScrollEnd.ts
@@ -1,0 +1,45 @@
+type WaitForScrollEndOptions = {
+  expectMovement?: boolean;
+  startY?: number;
+  stableFrames?: number;
+};
+
+export function waitForScrollEnd(
+  onDone: () => void,
+  {
+    expectMovement = false,
+    startY = window.scrollY,
+    stableFrames = 5,
+  }: WaitForScrollEndOptions = {}
+) {
+  if (!expectMovement) {
+    requestAnimationFrame(onDone);
+    return;
+  }
+
+  let last = window.scrollY;
+  let stable = 0;
+  let hasMoved = false;
+
+  const tick = () => {
+    if (Math.abs(window.scrollY - startY) > 1) {
+      hasMoved = true;
+    }
+
+    if (window.scrollY !== last) {
+      hasMoved = true;
+      stable = 0;
+      last = window.scrollY;
+    } else if (hasMoved) {
+      stable += 1;
+    }
+
+    if (hasMoved && stable >= stableFrames) {
+      onDone();
+    } else {
+      requestAnimationFrame(tick);
+    }
+  };
+
+  requestAnimationFrame(tick);
+}


### PR DESCRIPTION
…pography

- Narrow max-w-2xl reading column with smaller header (text-2xl/3xl)
- Add @tailwindcss/typography plugin; new BlogMDXContent component with prose base (16px, line-height 2) scoped to blog only, no other pages affected
- Cover image expands beyond column with negative margins (-mx-24)
- Tags use Space Mono font (new --font-mono token + Space_Mono from next/font)
- Replace IntersectionObserver TOC with @chenglou/pretext scroll detection: section boundaries calculated via canvas text measurement, active heading updates at 40% vh matching TOC click scroll target for consistency