### PR TITLE
Draft: home page editorial redesign

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,9 @@ import AppCardMusic from "@/components/AppCardMusic";
 import AppCardFilms from "@/components/AppCardFilms";
 import AppLink from "@/components/AppLink";
 import PhotoScrollGallery from "@/components/PhotoScrollGallery";
+import SidebarSection from "@/components/SidebarSection";
 import { filteredPosts, filteredFeaturedWorks, filteredPhotos } from "@/lib/content";
+import { TbArrowUpRight } from "react-icons/tb";
 
 export const metadata = {
   other: {
@@ -15,102 +17,135 @@ export const metadata = {
   },
 };
 
+const services = [
+  { index: "01", label: "UI/UX Design" },
+  { index: "02", label: "Design System" },
+  { index: "03", label: "AI Design Workflow" },
+];
+
+const EXPERIENCE_YEARS = 2026 - 2015;
+
 export default function IndexPage() {
-  // Get data directly in server component
   const posts = filteredPosts.slice(0, 4);
   const works = filteredFeaturedWorks.slice(0, 3);
   const photos = filteredPhotos.slice(0, 8);
 
   return (
     <AppLayout>
-        {/* Hero Section */}
-        <section className="grid min-h-[100dvh] place-content-center gap-10 py-12">
-          <div className="flex flex-col md:flex-row justify-between items-baseline">
-            <h1 className="text-4xl md:text-6xl font-bold font-heading tracking-tight leading-tight mb-6">
-              Desktop of Samuel
-            </h1>
-          </div>
-          <p className="text-muted-foreground text-lg leading-relaxed">
-            Full-stack UI/UX designer crafting websites & mobile applications with
-            bespoke experience.
-          </p>
-
-          {/* Cards Section */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-            <AppCardBook />
-            <AppCardMusic />
-            <AppCardCurrentlyPlaying />
-            <AppCardFilms />
-          </div>
-        </section>
-
-      {/* Portfolio Section */}
-      <div className="border-t border-muted pt-12 mt-12">
-        <h2 className="text-2xl md:text-3xl font-bold font-heading leading-tight mb-4">
-          Interaction and Experience Design
-        </h2>
-        <p className="text-muted-foreground leading-relaxed mb-8 max-w-prose">
-          Extensive experience delivering products in corporations and start-ups
+      {/* Hero — full viewport height, content pinned to bottom */}
+      <section className="min-h-[90dvh] flex flex-col justify-end pb-20 gap-10">
+        <p className="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">
+          00 — Samuel Wong, Hong Kong
         </p>
-
-        <AppLink href="/work" className="btn btn-primary mb-8">
-          View Process
-        </AppLink>
-        {works.map((post) => (
-          <AppListPortfolio key={post.slug} data={post} />
-        ))}
-      </div>
-
-      {/* Blog Section */}
-      <div className="border-t border-muted pt-12 mt-12">
-        <h2 className="text-2xl md:text-3xl font-bold font-heading leading-tight mb-4">
-          Notes on Design & Technology
-        </h2>
-        <p className="text-muted-foreground leading-relaxed mb-8 max-w-prose">
-          I write about design, technology and productivity.
+        <h1 className="text-5xl sm:text-7xl md:text-8xl font-bold font-heading leading-[0.95] text-foreground">
+          UI/UX designer
+          <br className="hidden sm:block" />
+          crafting digital
+          <br className="hidden sm:block" />
+          experiences
+        </h1>
+        <p className="text-lg text-muted-foreground leading-relaxed max-w-xl">
+          Full-stack product designer with {EXPERIENCE_YEARS}+ years delivering bespoke
+          interfaces for web3, finance, and travel — currently leading product design at
+          Pepperstone.
         </p>
-        <AppLink href="/blog" className="btn btn-primary mb-8">
-          Read my blog
+        {/* Live data cards */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 pt-4">
+          <AppCardBook />
+          <AppCardMusic />
+          <AppCardCurrentlyPlaying />
+          <AppCardFilms />
+        </div>
+      </section>
+
+      {/* Work */}
+      <SidebarSection label="01 — Work">
+        <p className="text-muted-foreground leading-relaxed mb-10 max-w-prose">
+          Extensive experience delivering products in corporations and start-ups across
+          finance, web3, and travel industries.
+        </p>
+        <div className="flex flex-col gap-8">
+          {works.map((post) => (
+            <AppListPortfolio key={post.slug} data={post} />
+          ))}
+        </div>
+        <AppLink
+          href="/work"
+          className="mt-10 inline-flex items-center gap-2 text-sm font-heading font-semibold uppercase tracking-widest hover:opacity-60 transition-opacity"
+        >
+          View all work <TbArrowUpRight size={16} />
         </AppLink>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-12">
+      </SidebarSection>
+
+      {/* Writing */}
+      <SidebarSection label="02 — Writing">
+        <p className="text-muted-foreground leading-relaxed mb-10 max-w-prose">
+          Notes on design process, technology, and productivity.
+        </p>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           {posts.map((post) => (
             <AppListBlog key={post.slug} data={post} />
           ))}
         </div>
-      </div>
-
-      {/* Tools Section
-      <div className="border-t border-muted pt-12 mt-12">
-        <h2 className="text-2xl md:text-3xl font-bold leading-tight mb-4">
-          Tools & Resources
-        </h2>
-        <p className="text-muted-foreground leading-relaxed mb-8 max-w-prose">
-          Best resources and tools I have been using. Guide on getting started
-          in design & code.
-        </p>
-        <AppLink href="/resources" className="btn btn-primary mb-8">
-          My awesome setup
-        </AppLink>
-      </div> */}
-
-      {/* Photo Gallery Section */}
-      <div className="border-t border-muted pt-12 mt-12 relative w-full overflow-hidden">
-        <h2 className="text-2xl md:text-3xl font-bold font-heading leading-tight mb-4">
-          Through the lens
-        </h2>
-        <p className="text-muted-foreground leading-relaxed mb-8 max-w-prose">
-          Sets of photos according to cities that I have visited.
-        </p>
         <AppLink
-          href="/photo"
-          className="btn btn-primary mb-6 inline-flex items-center gap-2"
+          href="/blog"
+          className="mt-10 inline-flex items-center gap-2 text-sm font-heading font-semibold uppercase tracking-widest hover:opacity-60 transition-opacity"
         >
-          View all journeys
+          Read the blog <TbArrowUpRight size={16} />
         </AppLink>
-        <div className="rounded-xl overflow-hidden shadow-lg">
+      </SidebarSection>
+
+      {/* Photo */}
+      <SidebarSection label="03 — Photo">
+        <p className="text-muted-foreground leading-relaxed mb-8 max-w-prose">
+          Sets of photos from cities I have visited.
+        </p>
+        <div className="overflow-hidden rounded-xl">
           <PhotoScrollGallery photos={photos} />
         </div>
-      </div>
+        <AppLink
+          href="/photo"
+          className="mt-8 inline-flex items-center gap-2 text-sm font-heading font-semibold uppercase tracking-widest hover:opacity-60 transition-opacity"
+        >
+          View all journeys <TbArrowUpRight size={16} />
+        </AppLink>
+      </SidebarSection>
+
+      {/* Services — editorial pill rows */}
+      <SidebarSection label="04 — Services">
+        <div className="flex flex-col -mt-6">
+          {services.map((svc) => (
+            <div
+              key={svc.label}
+              className="group flex items-center justify-between py-8 border-b border-border cursor-default"
+            >
+              <div className="flex items-baseline gap-6">
+                <span className="font-mono text-xs text-muted-foreground tabular-nums w-6 shrink-0">
+                  {svc.index}
+                </span>
+                <span className="text-3xl md:text-5xl font-bold font-heading group-hover:translate-x-1 transition-transform duration-200 ease-out">
+                  {svc.label}
+                </span>
+              </div>
+              <TbArrowUpRight
+                className="text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
+                size={24}
+              />
+            </div>
+          ))}
+        </div>
+        <div className="pt-16">
+          <p className="text-muted-foreground mb-6 max-w-prose">
+            Available for freelance engagements and design consulting.
+          </p>
+          <AppLink
+            href="mailto:desktopofsamuel@gmail.com"
+            className="inline-flex items-center gap-2 text-sm font-heading font-semibold uppercase tracking-widest hover:opacity-60 transition-opacity"
+          >
+            Get in touch <TbArrowUpRight size={16} />
+          </AppLink>
+        </div>
+      </SidebarSection>
     </AppLayout>
   );
 }

--- a/components/SidebarSection.tsx
+++ b/components/SidebarSection.tsx
@@ -1,0 +1,21 @@
+type SidebarSectionProps = {
+  label: string;
+  children: React.ReactNode;
+  leftAside?: React.ReactNode;
+};
+
+export default function SidebarSection({ label, children, leftAside }: SidebarSectionProps) {
+  return (
+    <div className="-mx-overhang px-overhang border-t border-border py-16 grid grid-cols-12 gap-x-8 gap-y-6">
+      <div className="col-span-12 md:col-span-3">
+        <div className="md:sticky md:top-[120px] flex flex-col gap-4">
+          {leftAside}
+          <span className="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">
+            {label}
+          </span>
+        </div>
+      </div>
+      <div className="col-span-12 md:col-span-9">{children}</div>
+    </div>
+  );
+}

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -43,6 +43,10 @@
   --color-border: var(--color-yellow-300);
   --color-outline: #e2e8f0;
 
+  /* Spatial tokens for editorial layout */
+  --spacing-page: 1.25rem;      /* 20px: horizontal page padding (matches AppLayout px-5) */
+  --spacing-overhang: 1rem;     /* 16px: divider overhang beyond content edge on each side */
+
   /* Font Weights */
   --font-weight-hairline: 100;
   --font-weight-thin: 200;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Full editorial redesign of `app/page.tsx` for the v4 dark-editorial design language, plus a new shared `SidebarSection` primitive.

### Section structure

| # | Label | Content |
|---|-------|---------|
| 00 | Hero | Mono eyebrow · text-8xl title · intro paragraph · 4-column live data cards (book / music / now playing / films) |
| 01 | Work | Intro blurb · 3 featured `AppListPortfolio` cards · "View all work" link |
| 02 | Writing | Intro blurb · 4 posts in 2-col `AppListBlog` grid · "Read the blog" link |
| 03 | Photo | Intro blurb · `PhotoScrollGallery` · "View all journeys" link |
| 04 | Services | 3 editorial pill rows (UI/UX Design · Design System · AI Design Workflow) · freelance CTA |

### New files

- **`components/SidebarSection.tsx`** — shared layout primitive: 12-col grid, `col-span-3` sticky label at `top-[120px]`, `col-span-9` content slot, optional `leftAside`, border-top dividers that overhang 16 px on each side via `-mx-overhang`.
- **`styles/theme.css`** — two new spacing tokens: `--spacing-overhang: 1rem` (16 px) and `--spacing-page: 1.25 rem` (20 px) so `SidebarSection` can use `px-overhang` / `-mx-overhang` without raw CSS-variable references in class strings.

### Content changes vs current `main`

| Content | Action |
|---------|--------|
| Hero h1 + intro paragraph | Replaced with numbered eyebrow + text-8xl multi-line title |
| Live data cards (book, music, now playing, films) | **Kept** — moved inside hero |
| Featured works (3 items) | **Kept** — now in `01 — Work` SidebarSection |
| Featured blog posts (4 items) | **Kept** — now in `02 — Writing` SidebarSection |
| Photo scroll gallery (8 photos) | **Kept** — now in `03 — Photo` SidebarSection |
| Tools / Resources section | Was already commented out in `main`; remains absent |
| Services section | **New** — `04 — Services` with 3 editorial pill rows |

### Tokens used

All class names reference Tailwind v4 semantic tokens only (`text-foreground`, `text-muted-foreground`, `bg-background`, `border-border`, `font-heading`, `font-mono`). No raw `var(--…)` references in JSX.

https://claude.ai/code/session_01SPmiy5NCrFGV3NhxQiNS3s
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPmiy5NCrFGV3NhxQiNS3s)_