### PR TITLE
Fix homepage Work section gap to match /work page spacing

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -63,7 +63,7 @@ export default function IndexPage() {
           Extensive experience delivering products in corporations and start-ups
           across finance, web3, and travel industries.
         </p>
-        <div className="flex flex-col gap-8">
+        <div className="flex flex-col">
           {works.map((post) => (
             <AppListPortfolio key={post.slug} data={post} />
           ))}


### PR DESCRIPTION
The flex container had gap-8 stacked on top of AppListPortfolio's own my-10 margins, doubling the vertical gap compared to /work.